### PR TITLE
 Change From<Float> to TryFrom<Float> 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,6 @@ license = "MIT"
 edition = "2018"
 
 [dependencies]
-num = "0.1"
-byteorder = "0.5"
+num = "0.2"
+byteorder = "1.3"
 libflate = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/sile/eetf"
 readme = "README.md"
 keywords = ["erlang"]
 license = "MIT"
+edition = "2018"
 
 [dependencies]
 num = "0.1"

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -1,26 +1,33 @@
-use std;
-use std::str;
-use std::io;
-use std::io::Write;
-use std::fmt;
-use std::error;
-use std::convert::From;
+use super::*;
+use crate::convert::TryAsRef;
+use crate::convert::TryInto;
+use byteorder::BigEndian;
 use byteorder::ReadBytesExt;
 use byteorder::WriteBytesExt;
-use byteorder::BigEndian;
-use num::bigint::BigInt;
 use libflate::zlib;
-use super::*;
-use convert::TryAsRef;
-use convert::TryInto;
+use num::bigint::BigInt;
+use std;
+use std::convert::From;
+use std::error;
+use std::fmt;
+use std::io;
+use std::io::Write;
+use std::str;
 
 /// Errors which can occur when decoding a term
 #[derive(Debug)]
 pub enum DecodeError {
     Io(io::Error),
-    UnsupportedVersion { version: u8 },
-    UnknownTag { tag: u8 },
-    UnexpectedType { value: Term, expected: String },
+    UnsupportedVersion {
+        version: u8,
+    },
+    UnknownTag {
+        tag: u8,
+    },
+    UnexpectedType {
+        value: Term,
+        expected: String,
+    },
     OutOfRange {
         value: i32,
         range: std::ops::Range<i32>,
@@ -33,16 +40,15 @@ impl fmt::Display for DecodeError {
             Io(ref x) => x.fmt(f),
             UnsupportedVersion { version } => write!(f, "Unsupported version {}", version),
             UnknownTag { tag } => write!(f, "Unknown tag {}", tag),
-            UnexpectedType { ref value, ref expected } => {
-                write!(f, "{} is not a {}", value, expected)
-            }
-            OutOfRange { value, ref range } => {
-                write!(f,
-                       "{} is out of range {}..{}",
-                       value,
-                       range.start,
-                       range.end)
-            }
+            UnexpectedType {
+                ref value,
+                ref expected,
+            } => write!(f, "{} is not a {}", value, expected),
+            OutOfRange { value, ref range } => write!(
+                f,
+                "{} is out of range {}..{}",
+                value, range.start, range.end
+            ),
         }
     }
 }
@@ -57,9 +63,9 @@ impl error::Error for DecodeError {
             OutOfRange { .. } => "Integer value is out of range",
         }
     }
-    fn cause(&self) -> Option<&error::Error> {
+    fn cause(&self) -> Option<&(dyn error::Error + 'static)> {
         match *self {
-            DecodeError::Io(ref x) => x.cause(),
+            DecodeError::Io(ref x) => x.source(),
             _ => None,
         }
     }
@@ -84,16 +90,16 @@ impl fmt::Display for EncodeError {
         match *self {
             Io(ref x) => x.fmt(f),
             TooLongAtomName(ref x) => write!(f, "Too long atom name: {} bytes", x.name.len()),
-            TooLargeInteger(ref x) => {
-                write!(f,
-                       "Too large integer value: {} bytes required to encode",
-                       x.value.to_bytes_le().1.len())
-            }
-            TooLargeReferenceId(ref x) => {
-                write!(f,
-                       "Too large reference ID: {} bytes required to encode",
-                       x.id.len() * 4)
-            }
+            TooLargeInteger(ref x) => write!(
+                f,
+                "Too large integer value: {} bytes required to encode",
+                x.value.to_bytes_le().1.len()
+            ),
+            TooLargeReferenceId(ref x) => write!(
+                f,
+                "Too large reference ID: {} bytes required to encode",
+                x.id.len() * 4
+            ),
         }
     }
 }
@@ -107,9 +113,9 @@ impl error::Error for EncodeError {
             TooLargeReferenceId(_) => "Too large reference identifier",
         }
     }
-    fn cause(&self) -> Option<&error::Error> {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match *self {
-            EncodeError::Io(ref x) => x.cause(),
+            EncodeError::Io(ref x) => x.source(),
             _ => None,
         }
     }
@@ -166,11 +172,11 @@ impl<R: io::Read> Decoder<R> {
         }
     }
     pub fn decode(mut self) -> DecodeResult {
-        let version = try!(self.reader.read_u8());
+        let version = r#try!(self.reader.read_u8());
         if version != VERSION {
             return Err(DecodeError::UnsupportedVersion { version: version });
         }
-        let tag = try!(self.reader.read_u8());
+        let tag = r#try!(self.reader.read_u8());
         match tag {
             COMPRESSED_TERM => self.decode_compressed_term(),
             DISTRIBUTION_HEADER => unimplemented!(),
@@ -178,7 +184,7 @@ impl<R: io::Read> Decoder<R> {
         }
     }
     fn decode_term(&mut self) -> DecodeResult {
-        let tag = try!(self.reader.read_u8());
+        let tag = r#try!(self.reader.read_u8());
         self.decode_term_with_tag(tag)
     }
     fn decode_term_with_tag(&mut self, tag: u8) -> DecodeResult {
@@ -213,8 +219,8 @@ impl<R: io::Read> Decoder<R> {
         }
     }
     fn decode_compressed_term(&mut self) -> DecodeResult {
-        let _uncompressed_size = try!(self.reader.read_u32::<BigEndian>()) as usize;
-        let zlib_decoder = try!(zlib::Decoder::new(&mut self.reader));
+        let _uncompressed_size = r#try!(self.reader.read_u32::<BigEndian>()) as usize;
+        let zlib_decoder = r#try!(zlib::Decoder::new(&mut self.reader));
         let mut decoder = Decoder::new(zlib_decoder);
         decoder.decode_term()
     }
@@ -222,63 +228,69 @@ impl<R: io::Read> Decoder<R> {
         Ok(Term::from(List::nil()))
     }
     fn decode_string_ext(&mut self) -> DecodeResult {
-        let size = try!(self.reader.read_u16::<BigEndian>()) as usize;
+        let size = r#try!(self.reader.read_u16::<BigEndian>()) as usize;
         let mut elements = Vec::with_capacity(size);
         for _ in 0..size {
-            elements.push(Term::from(FixInteger::from(try!(self.reader.read_u8()) as i32)));
+            elements.push(Term::from(FixInteger::from(
+                r#try!(self.reader.read_u8()) as i32
+            )));
         }
         Ok(Term::from(List::from(elements)))
     }
     fn decode_list_ext(&mut self) -> DecodeResult {
-        let count = try!(self.reader.read_u32::<BigEndian>()) as usize;
+        let count = r#try!(self.reader.read_u32::<BigEndian>()) as usize;
         let mut elements = Vec::with_capacity(count);
         for _ in 0..count {
-            elements.push(try!(self.decode_term()));
+            elements.push(r#try!(self.decode_term()));
         }
-        let last = try!(self.decode_term());
-        if last.try_as_ref().map(|l: &List| l.is_nil()).unwrap_or(false) {
+        let last = r#try!(self.decode_term());
+        if last
+            .try_as_ref()
+            .map(|l: &List| l.is_nil())
+            .unwrap_or(false)
+        {
             Ok(Term::from(List::from(elements)))
         } else {
             Ok(Term::from(ImproperList::from((elements, last))))
         }
     }
     fn decode_small_tuple_ext(&mut self) -> DecodeResult {
-        let count = try!(self.reader.read_u8()) as usize;
+        let count = r#try!(self.reader.read_u8()) as usize;
         let mut elements = Vec::with_capacity(count);
         for _ in 0..count {
-            elements.push(try!(self.decode_term()));
+            elements.push(r#try!(self.decode_term()));
         }
         Ok(Term::from(Tuple::from(elements)))
     }
     fn decode_large_tuple_ext(&mut self) -> DecodeResult {
-        let count = try!(self.reader.read_u32::<BigEndian>()) as usize;
+        let count = r#try!(self.reader.read_u32::<BigEndian>()) as usize;
         let mut elements = Vec::with_capacity(count);
         for _ in 0..count {
-            elements.push(try!(self.decode_term()));
+            elements.push(r#try!(self.decode_term()));
         }
         Ok(Term::from(Tuple::from(elements)))
     }
     fn decode_map_ext(&mut self) -> DecodeResult {
-        let count = try!(self.reader.read_u32::<BigEndian>()) as usize;
+        let count = r#try!(self.reader.read_u32::<BigEndian>()) as usize;
         let mut entries = Vec::with_capacity(count);
         for _ in 0..count {
-            let k = try!(self.decode_term());
-            let v = try!(self.decode_term());
+            let k = r#try!(self.decode_term());
+            let v = r#try!(self.decode_term());
             entries.push((k, v));
         }
         Ok(Term::from(Map::from(entries)))
     }
     fn decode_binary_ext(&mut self) -> DecodeResult {
-        let size = try!(self.reader.read_u32::<BigEndian>()) as usize;
+        let size = r#try!(self.reader.read_u32::<BigEndian>()) as usize;
         let mut buf = vec![0; size];
-        try!(self.reader.read_exact(&mut buf));
+        r#try!(self.reader.read_exact(&mut buf));
         Ok(Term::from(Binary::from(buf)))
     }
     fn decode_bit_binary_ext(&mut self) -> DecodeResult {
-        let size = try!(self.reader.read_u32::<BigEndian>()) as usize;
-        let tail_bits_size = try!(self.reader.read_u8());
+        let size = r#try!(self.reader.read_u32::<BigEndian>()) as usize;
+        let tail_bits_size = r#try!(self.reader.read_u8());
         let mut buf = vec![0; size];
-        try!(self.reader.read_exact(&mut buf));
+        r#try!(self.reader.read_exact(&mut buf));
         if !buf.is_empty() {
             let last = buf[size - 1] >> (8 - tail_bits_size);
             buf[size - 1] = last;
@@ -286,45 +298,42 @@ impl<R: io::Read> Decoder<R> {
         Ok(Term::from(BitBinary::from((buf, tail_bits_size))))
     }
     fn decode_pid_ext(&mut self) -> DecodeResult {
-        let node = try!(self.decode_term().and_then(aux::term_into_atom));
+        let node = r#try!(self.decode_term().and_then(aux::term_into_atom));
         Ok(Term::from(Pid {
             node: node,
-            id: try!(self.reader.read_u32::<BigEndian>()),
-            serial: try!(self.reader.read_u32::<BigEndian>()),
-            creation: try!(self.reader.read_u8()),
+            id: r#try!(self.reader.read_u32::<BigEndian>()),
+            serial: r#try!(self.reader.read_u32::<BigEndian>()),
+            creation: r#try!(self.reader.read_u8()),
         }))
     }
     fn decode_port_ext(&mut self) -> DecodeResult {
-        let node: Atom = try!(self.decode_term()
-            .and_then(|t| {
-                t.try_into().map_err(|t| {
-                    DecodeError::UnexpectedType {
-                        value: t,
-                        expected: "Atom".to_string(),
-                    }
-                })
-            }));
+        let node: Atom = r#try!(self.decode_term().and_then(|t| {
+            t.try_into().map_err(|t| DecodeError::UnexpectedType {
+                value: t,
+                expected: "Atom".to_string(),
+            })
+        }));
         Ok(Term::from(Port {
             node: node,
-            id: try!(self.reader.read_u32::<BigEndian>()),
-            creation: try!(self.reader.read_u8()),
+            id: r#try!(self.reader.read_u32::<BigEndian>()),
+            creation: r#try!(self.reader.read_u8()),
         }))
     }
     fn decode_reference_ext(&mut self) -> DecodeResult {
-        let node = try!(self.decode_term().and_then(aux::term_into_atom));
+        let node = r#try!(self.decode_term().and_then(aux::term_into_atom));
         Ok(Term::from(Reference {
             node: node,
-            id: vec![try!(self.reader.read_u32::<BigEndian>())],
-            creation: try!(self.reader.read_u8()),
+            id: vec![r#try!(self.reader.read_u32::<BigEndian>())],
+            creation: r#try!(self.reader.read_u8()),
         }))
     }
     fn decode_new_reference_ext(&mut self) -> DecodeResult {
-        let id_count = try!(self.reader.read_u16::<BigEndian>()) as usize;
-        let node = try!(self.decode_term().and_then(aux::term_into_atom));
-        let creation = try!(self.reader.read_u8());
+        let id_count = r#try!(self.reader.read_u16::<BigEndian>()) as usize;
+        let node = r#try!(self.decode_term().and_then(aux::term_into_atom));
+        let creation = r#try!(self.reader.read_u8());
         let mut id = Vec::with_capacity(id_count);
         for _ in 0..id_count {
-            id.push(try!(self.reader.read_u32::<BigEndian>()));
+            id.push(r#try!(self.reader.read_u32::<BigEndian>()));
         }
         Ok(Term::from(Reference {
             node: node,
@@ -333,9 +342,10 @@ impl<R: io::Read> Decoder<R> {
         }))
     }
     fn decode_export_ext(&mut self) -> DecodeResult {
-        let module = try!(self.decode_term().and_then(aux::term_into_atom));
-        let function = try!(self.decode_term().and_then(aux::term_into_atom));
-        let arity = try!(self.decode_term()
+        let module = r#try!(self.decode_term().and_then(aux::term_into_atom));
+        let function = r#try!(self.decode_term().and_then(aux::term_into_atom));
+        let arity = r#try!(self
+            .decode_term()
             .and_then(|t| aux::term_into_ranged_integer(t, 0..0xFF))) as u8;
         Ok(Term::from(ExternalFun {
             module: module,
@@ -344,14 +354,14 @@ impl<R: io::Read> Decoder<R> {
         }))
     }
     fn decode_fun_ext(&mut self) -> DecodeResult {
-        let num_free = try!(self.reader.read_u32::<BigEndian>());
-        let pid = try!(self.decode_term().and_then(aux::term_into_pid));
-        let module = try!(self.decode_term().and_then(aux::term_into_atom));
-        let index = try!(self.decode_term().and_then(aux::term_into_fix_integer));
-        let uniq = try!(self.decode_term().and_then(aux::term_into_fix_integer));
+        let num_free = r#try!(self.reader.read_u32::<BigEndian>());
+        let pid = r#try!(self.decode_term().and_then(aux::term_into_pid));
+        let module = r#try!(self.decode_term().and_then(aux::term_into_atom));
+        let index = r#try!(self.decode_term().and_then(aux::term_into_fix_integer));
+        let uniq = r#try!(self.decode_term().and_then(aux::term_into_fix_integer));
         let mut vars = Vec::with_capacity(num_free as usize);
         for _ in 0..num_free {
-            vars.push(try!(self.decode_term()));
+            vars.push(r#try!(self.decode_term()));
         }
         Ok(Term::from(InternalFun::Old {
             module: module,
@@ -362,19 +372,19 @@ impl<R: io::Read> Decoder<R> {
         }))
     }
     fn decode_new_fun_ext(&mut self) -> DecodeResult {
-        let _size = try!(self.reader.read_u32::<BigEndian>());
-        let arity = try!(self.reader.read_u8());
+        let _size = r#try!(self.reader.read_u32::<BigEndian>());
+        let arity = r#try!(self.reader.read_u8());
         let mut uniq = [0; 16];
-        try!(self.reader.read_exact(&mut uniq));
-        let index = try!(self.reader.read_u32::<BigEndian>());
-        let num_free = try!(self.reader.read_u32::<BigEndian>());
-        let module = try!(self.decode_term().and_then(aux::term_into_atom));
-        let old_index = try!(self.decode_term().and_then(aux::term_into_fix_integer));
-        let old_uniq = try!(self.decode_term().and_then(aux::term_into_fix_integer));
-        let pid = try!(self.decode_term().and_then(aux::term_into_pid));
+        r#try!(self.reader.read_exact(&mut uniq));
+        let index = r#try!(self.reader.read_u32::<BigEndian>());
+        let num_free = r#try!(self.reader.read_u32::<BigEndian>());
+        let module = r#try!(self.decode_term().and_then(aux::term_into_atom));
+        let old_index = r#try!(self.decode_term().and_then(aux::term_into_fix_integer));
+        let old_uniq = r#try!(self.decode_term().and_then(aux::term_into_fix_integer));
+        let pid = r#try!(self.decode_term().and_then(aux::term_into_pid));
         let mut vars = Vec::with_capacity(num_free as usize);
         for _ in 0..num_free {
-            vars.push(try!(self.decode_term()));
+            vars.push(r#try!(self.decode_term()));
         }
         Ok(Term::from(InternalFun::New {
             module: module,
@@ -388,71 +398,72 @@ impl<R: io::Read> Decoder<R> {
         }))
     }
     fn decode_new_float_ext(&mut self) -> DecodeResult {
-        let value = try!(self.reader.read_f64::<BigEndian>());
+        let value = r#try!(self.reader.read_f64::<BigEndian>());
         Ok(Term::from(Float::from(value)))
     }
     fn decode_float_ext(&mut self) -> DecodeResult {
         let mut buf = [0; 31];
-        try!(self.reader.read_exact(&mut buf));
-        let float_str = try!(str::from_utf8(&mut buf)
-                .or_else(|e| aux::invalid_data_error(e.to_string())))
-            .trim_right_matches(0 as char);
-        let value = try!(float_str.parse::<f32>()
+        r#try!(self.reader.read_exact(&mut buf));
+        let float_str =
+            r#try!(str::from_utf8(&mut buf).or_else(|e| aux::invalid_data_error(e.to_string())))
+                .trim_end_matches(0 as char);
+        let value = r#try!(float_str
+            .parse::<f32>()
             .or_else(|e| aux::invalid_data_error(e.to_string())));
         Ok(Term::from(Float::from(value as f64)))
     }
     fn decode_small_integer_ext(&mut self) -> DecodeResult {
-        let value = try!(self.reader.read_u8());
+        let value = r#try!(self.reader.read_u8());
         Ok(Term::from(FixInteger::from(value as i32)))
     }
     fn decode_integer_ext(&mut self) -> DecodeResult {
-        let value = try!(self.reader.read_i32::<BigEndian>());
+        let value = r#try!(self.reader.read_i32::<BigEndian>());
         Ok(Term::from(FixInteger::from(value)))
     }
     fn decode_small_big_ext(&mut self) -> DecodeResult {
-        let count = try!(self.reader.read_u8()) as usize;
-        let sign = try!(self.reader.read_u8());
+        let count = r#try!(self.reader.read_u8()) as usize;
+        let sign = r#try!(self.reader.read_u8());
         self.buf.resize(count, 0);
-        try!(self.reader.read_exact(&mut self.buf));
-        let value = BigInt::from_bytes_le(try!(aux::byte_to_sign(sign)), &self.buf);
+        r#try!(self.reader.read_exact(&mut self.buf));
+        let value = BigInt::from_bytes_le(r#try!(aux::byte_to_sign(sign)), &self.buf);
         Ok(Term::from(BigInteger { value: value }))
     }
     fn decode_large_big_ext(&mut self) -> DecodeResult {
-        let count = try!(self.reader.read_u32::<BigEndian>()) as usize;
-        let sign = try!(self.reader.read_u8());
+        let count = r#try!(self.reader.read_u32::<BigEndian>()) as usize;
+        let sign = r#try!(self.reader.read_u8());
         self.buf.resize(count, 0);
-        try!(self.reader.read_exact(&mut self.buf));
-        let value = BigInt::from_bytes_le(try!(aux::byte_to_sign(sign)), &self.buf);
+        r#try!(self.reader.read_exact(&mut self.buf));
+        let value = BigInt::from_bytes_le(r#try!(aux::byte_to_sign(sign)), &self.buf);
         Ok(Term::from(BigInteger { value: value }))
     }
     fn decode_atom_ext(&mut self) -> DecodeResult {
-        let len = try!(self.reader.read_u16::<BigEndian>());
+        let len = r#try!(self.reader.read_u16::<BigEndian>());
         self.buf.resize(len as usize, 0);
-        try!(self.reader.read_exact(&mut self.buf));
-        let name = try!(aux::latin1_bytes_to_string(&self.buf));
+        r#try!(self.reader.read_exact(&mut self.buf));
+        let name = r#try!(aux::latin1_bytes_to_string(&self.buf));
         Ok(Term::from(Atom { name: name }))
     }
     fn decode_small_atom_ext(&mut self) -> DecodeResult {
-        let len = try!(self.reader.read_u8());
+        let len = r#try!(self.reader.read_u8());
         self.buf.resize(len as usize, 0);
-        try!(self.reader.read_exact(&mut self.buf));
-        let name = try!(aux::latin1_bytes_to_string(&self.buf));
+        r#try!(self.reader.read_exact(&mut self.buf));
+        let name = r#try!(aux::latin1_bytes_to_string(&self.buf));
         Ok(Term::from(Atom { name: name }))
     }
     fn decode_atom_utf8_ext(&mut self) -> DecodeResult {
-        let len = try!(self.reader.read_u16::<BigEndian>());
+        let len = r#try!(self.reader.read_u16::<BigEndian>());
         self.buf.resize(len as usize, 0);
-        try!(self.reader.read_exact(&mut self.buf));
-        let name = try!(str::from_utf8(&self.buf)
-            .or_else(|e| aux::invalid_data_error(e.to_string())));
+        r#try!(self.reader.read_exact(&mut self.buf));
+        let name =
+            r#try!(str::from_utf8(&self.buf).or_else(|e| aux::invalid_data_error(e.to_string())));
         Ok(Term::from(Atom::from(name)))
     }
     fn decode_small_atom_utf8_ext(&mut self) -> DecodeResult {
-        let len = try!(self.reader.read_u8());
+        let len = r#try!(self.reader.read_u8());
         self.buf.resize(len as usize, 0);
-        try!(self.reader.read_exact(&mut self.buf));
-        let name = try!(str::from_utf8(&self.buf)
-            .or_else(|e| aux::invalid_data_error(e.to_string())));
+        r#try!(self.reader.read_exact(&mut self.buf));
+        let name =
+            r#try!(str::from_utf8(&self.buf).or_else(|e| aux::invalid_data_error(e.to_string())));
         Ok(Term::from(Atom::from(name)))
     }
 }
@@ -465,7 +476,7 @@ impl<W: io::Write> Encoder<W> {
         Encoder { writer: writer }
     }
     pub fn encode(mut self, term: &Term) -> EncodeResult {
-        try!(self.writer.write_u8(VERSION));
+        r#try!(self.writer.write_u8(VERSION));
         self.encode_term(term)
     }
     fn encode_term(&mut self, term: &Term) -> EncodeResult {
@@ -488,7 +499,7 @@ impl<W: io::Write> Encoder<W> {
         }
     }
     fn encode_nil(&mut self) -> EncodeResult {
-        try!(self.writer.write_u8(NIL_EXT));
+        r#try!(self.writer.write_u8(NIL_EXT));
         Ok(())
     }
     fn encode_list(&mut self, x: &List) -> EncodeResult {
@@ -496,75 +507,79 @@ impl<W: io::Write> Encoder<W> {
             e.try_as_ref()
                 .and_then(|&FixInteger { value: i }| if i < 0x100 { Some(i as u8) } else { None })
         };
-        if !x.elements.is_empty() && x.elements.len() <= std::u16::MAX as usize &&
-           x.elements.iter().all(|e| to_byte(e).is_some()) {
-            try!(self.writer.write_u8(STRING_EXT));
-            try!(self.writer.write_u16::<BigEndian>(x.elements.len() as u16));
+        if !x.elements.is_empty()
+            && x.elements.len() <= std::u16::MAX as usize
+            && x.elements.iter().all(|e| to_byte(e).is_some())
+        {
+            r#try!(self.writer.write_u8(STRING_EXT));
+            r#try!(self.writer.write_u16::<BigEndian>(x.elements.len() as u16));
             for b in x.elements.iter().map(|e| to_byte(e).unwrap()) {
-                try!(self.writer.write_u8(b));
+                r#try!(self.writer.write_u8(b));
             }
         } else {
             if !x.is_nil() {
-                try!(self.writer.write_u8(LIST_EXT));
-                try!(self.writer.write_u32::<BigEndian>(x.elements.len() as u32));
+                r#try!(self.writer.write_u8(LIST_EXT));
+                r#try!(self.writer.write_u32::<BigEndian>(x.elements.len() as u32));
                 for e in &x.elements {
-                    try!(self.encode_term(e));
+                    r#try!(self.encode_term(e));
                 }
             }
-            try!(self.encode_nil());
+            r#try!(self.encode_nil());
         }
         Ok(())
     }
     fn encode_improper_list(&mut self, x: &ImproperList) -> EncodeResult {
-        try!(self.writer.write_u8(LIST_EXT));
-        try!(self.writer.write_u32::<BigEndian>(x.elements.len() as u32));
+        r#try!(self.writer.write_u8(LIST_EXT));
+        r#try!(self.writer.write_u32::<BigEndian>(x.elements.len() as u32));
         for e in &x.elements {
-            try!(self.encode_term(e));
+            r#try!(self.encode_term(e));
         }
-        try!(self.encode_term(&x.last));
+        r#try!(self.encode_term(&x.last));
         Ok(())
     }
     fn encode_tuple(&mut self, x: &Tuple) -> EncodeResult {
         if x.elements.len() < 0x100 {
-            try!(self.writer.write_u8(SMALL_TUPLE_EXT));
-            try!(self.writer.write_u8(x.elements.len() as u8));
+            r#try!(self.writer.write_u8(SMALL_TUPLE_EXT));
+            r#try!(self.writer.write_u8(x.elements.len() as u8));
         } else {
-            try!(self.writer.write_u8(LARGE_TUPLE_EXT));
-            try!(self.writer.write_u32::<BigEndian>(x.elements.len() as u32));
+            r#try!(self.writer.write_u8(LARGE_TUPLE_EXT));
+            r#try!(self.writer.write_u32::<BigEndian>(x.elements.len() as u32));
         }
         for e in &x.elements {
-            try!(self.encode_term(e));
+            r#try!(self.encode_term(e));
         }
         Ok(())
     }
     fn encode_map(&mut self, x: &Map) -> EncodeResult {
-        try!(self.writer.write_u8(MAP_EXT));
-        try!(self.writer.write_u32::<BigEndian>(x.entries.len() as u32));
+        r#try!(self.writer.write_u8(MAP_EXT));
+        r#try!(self.writer.write_u32::<BigEndian>(x.entries.len() as u32));
         for &(ref k, ref v) in &x.entries {
-            try!(self.encode_term(k));
-            try!(self.encode_term(v));
+            r#try!(self.encode_term(k));
+            r#try!(self.encode_term(v));
         }
         Ok(())
     }
     fn encode_binary(&mut self, x: &Binary) -> EncodeResult {
-        try!(self.writer.write_u8(BINARY_EXT));
-        try!(self.writer.write_u32::<BigEndian>(x.bytes.len() as u32));
-        try!(self.writer.write_all(&x.bytes));
+        r#try!(self.writer.write_u8(BINARY_EXT));
+        r#try!(self.writer.write_u32::<BigEndian>(x.bytes.len() as u32));
+        r#try!(self.writer.write_all(&x.bytes));
         Ok(())
     }
     fn encode_bit_binary(&mut self, x: &BitBinary) -> EncodeResult {
-        try!(self.writer.write_u8(BIT_BINARY_EXT));
-        try!(self.writer.write_u32::<BigEndian>(x.bytes.len() as u32));
-        try!(self.writer.write_u8(x.tail_bits_size));
+        r#try!(self.writer.write_u8(BIT_BINARY_EXT));
+        r#try!(self.writer.write_u32::<BigEndian>(x.bytes.len() as u32));
+        r#try!(self.writer.write_u8(x.tail_bits_size));
         if !x.bytes.is_empty() {
-            try!(self.writer.write_all(&x.bytes[0..x.bytes.len() - 1]));
-            try!(self.writer.write_u8(x.bytes[x.bytes.len() - 1] << (8 - x.tail_bits_size)));
+            r#try!(self.writer.write_all(&x.bytes[0..x.bytes.len() - 1]));
+            r#try!(self
+                .writer
+                .write_u8(x.bytes[x.bytes.len() - 1] << (8 - x.tail_bits_size)));
         }
         Ok(())
     }
     fn encode_float(&mut self, x: &Float) -> EncodeResult {
-        try!(self.writer.write_u8(NEW_FLOAT_EXT));
-        try!(self.writer.write_f64::<BigEndian>(x.value));
+        r#try!(self.writer.write_u8(NEW_FLOAT_EXT));
+        r#try!(self.writer.write_f64::<BigEndian>(x.value));
         Ok(())
     }
     fn encode_atom(&mut self, x: &Atom) -> EncodeResult {
@@ -574,114 +589,122 @@ impl<W: io::Write> Encoder<W> {
 
         let is_ascii = x.name.as_bytes().iter().all(|&c| c < 0x80);
         if is_ascii {
-            try!(self.writer.write_u8(ATOM_EXT));
+            r#try!(self.writer.write_u8(ATOM_EXT));
         } else {
-            try!(self.writer.write_u8(ATOM_UTF8_EXT));
+            r#try!(self.writer.write_u8(ATOM_UTF8_EXT));
         }
-        try!(self.writer.write_u16::<BigEndian>(x.name.len() as u16));
-        try!(self.writer.write_all(x.name.as_bytes()));
+        r#try!(self.writer.write_u16::<BigEndian>(x.name.len() as u16));
+        r#try!(self.writer.write_all(x.name.as_bytes()));
         Ok(())
     }
     fn encode_fix_integer(&mut self, x: &FixInteger) -> EncodeResult {
         if 0 <= x.value && x.value <= std::u8::MAX as i32 {
-            try!(self.writer.write_u8(SMALL_INTEGER_EXT));
-            try!(self.writer.write_u8(x.value as u8));
+            r#try!(self.writer.write_u8(SMALL_INTEGER_EXT));
+            r#try!(self.writer.write_u8(x.value as u8));
         } else {
-            try!(self.writer.write_u8(INTEGER_EXT));
-            try!(self.writer.write_i32::<BigEndian>(x.value as i32));
+            r#try!(self.writer.write_u8(INTEGER_EXT));
+            r#try!(self.writer.write_i32::<BigEndian>(x.value as i32));
         }
         Ok(())
     }
     fn encode_big_integer(&mut self, x: &BigInteger) -> EncodeResult {
         let (sign, bytes) = x.value.to_bytes_le();
         if bytes.len() <= std::u8::MAX as usize {
-            try!(self.writer.write_u8(SMALL_BIG_EXT));
-            try!(self.writer.write_u8(bytes.len() as u8));
+            r#try!(self.writer.write_u8(SMALL_BIG_EXT));
+            r#try!(self.writer.write_u8(bytes.len() as u8));
         } else if bytes.len() <= std::u32::MAX as usize {
-            try!(self.writer.write_u8(LARGE_BIG_EXT));
-            try!(self.writer.write_u32::<BigEndian>(bytes.len() as u32));
+            r#try!(self.writer.write_u8(LARGE_BIG_EXT));
+            r#try!(self.writer.write_u32::<BigEndian>(bytes.len() as u32));
         } else {
             return Err(EncodeError::TooLargeInteger(x.clone()));
         }
-        try!(self.writer.write_u8(aux::sign_to_byte(sign)));
-        try!(self.writer.write_all(&bytes));
+        r#try!(self.writer.write_u8(aux::sign_to_byte(sign)));
+        r#try!(self.writer.write_all(&bytes));
         Ok(())
     }
     fn encode_pid(&mut self, x: &Pid) -> EncodeResult {
-        try!(self.writer.write_u8(PID_EXT));
-        try!(self.encode_atom(&x.node));
-        try!(self.writer.write_u32::<BigEndian>(x.id));
-        try!(self.writer.write_u32::<BigEndian>(x.serial));
-        try!(self.writer.write_u8(x.creation));
+        r#try!(self.writer.write_u8(PID_EXT));
+        r#try!(self.encode_atom(&x.node));
+        r#try!(self.writer.write_u32::<BigEndian>(x.id));
+        r#try!(self.writer.write_u32::<BigEndian>(x.serial));
+        r#try!(self.writer.write_u8(x.creation));
         Ok(())
     }
     fn encode_port(&mut self, x: &Port) -> EncodeResult {
-        try!(self.writer.write_u8(PORT_EXT));
-        try!(self.encode_atom(&x.node));
-        try!(self.writer.write_u32::<BigEndian>(x.id));
-        try!(self.writer.write_u8(x.creation));
+        r#try!(self.writer.write_u8(PORT_EXT));
+        r#try!(self.encode_atom(&x.node));
+        r#try!(self.writer.write_u32::<BigEndian>(x.id));
+        r#try!(self.writer.write_u8(x.creation));
         Ok(())
     }
     fn encode_reference(&mut self, x: &Reference) -> EncodeResult {
-        try!(self.writer.write_u8(NEW_REFERENCE_EXT));
+        r#try!(self.writer.write_u8(NEW_REFERENCE_EXT));
         if x.id.len() > std::u16::MAX as usize {
             return Err(EncodeError::TooLargeReferenceId(x.clone()));
         }
-        try!(self.writer.write_u16::<BigEndian>(x.id.len() as u16));
-        try!(self.encode_atom(&x.node));
-        try!(self.writer.write_u8(x.creation));
+        r#try!(self.writer.write_u16::<BigEndian>(x.id.len() as u16));
+        r#try!(self.encode_atom(&x.node));
+        r#try!(self.writer.write_u8(x.creation));
         for n in &x.id {
-            try!(self.writer.write_u32::<BigEndian>(*n));
+            r#try!(self.writer.write_u32::<BigEndian>(*n));
         }
         Ok(())
     }
     fn encode_external_fun(&mut self, x: &ExternalFun) -> EncodeResult {
-        try!(self.writer.write_u8(EXPORT_EXT));
-        try!(self.encode_atom(&x.module));
-        try!(self.encode_atom(&x.function));
-        try!(self.encode_fix_integer(&FixInteger::from(x.arity as i32)));
+        r#try!(self.writer.write_u8(EXPORT_EXT));
+        r#try!(self.encode_atom(&x.module));
+        r#try!(self.encode_atom(&x.function));
+        r#try!(self.encode_fix_integer(&FixInteger::from(x.arity as i32)));
         Ok(())
     }
     fn encode_internal_fun(&mut self, x: &InternalFun) -> EncodeResult {
         match *x {
-            InternalFun::Old { ref module, ref pid, ref free_vars, index, uniq } => {
-                try!(self.writer.write_u8(FUN_EXT));
-                try!(self.writer.write_u32::<BigEndian>(free_vars.len() as u32));
-                try!(self.encode_pid(pid));
-                try!(self.encode_atom(module));
-                try!(self.encode_fix_integer(&FixInteger::from(index)));
-                try!(self.encode_fix_integer(&FixInteger::from(uniq)));
+            InternalFun::Old {
+                ref module,
+                ref pid,
+                ref free_vars,
+                index,
+                uniq,
+            } => {
+                r#try!(self.writer.write_u8(FUN_EXT));
+                r#try!(self.writer.write_u32::<BigEndian>(free_vars.len() as u32));
+                r#try!(self.encode_pid(pid));
+                r#try!(self.encode_atom(module));
+                r#try!(self.encode_fix_integer(&FixInteger::from(index)));
+                r#try!(self.encode_fix_integer(&FixInteger::from(uniq)));
                 for v in free_vars {
-                    try!(self.encode_term(v));
+                    r#try!(self.encode_term(v));
                 }
             }
-            InternalFun::New { ref module,
-                               arity,
-                               ref pid,
-                               ref free_vars,
-                               index,
-                               ref uniq,
-                               old_index,
-                               old_uniq } => {
-                try!(self.writer.write_u8(NEW_FUN_EXT));
+            InternalFun::New {
+                ref module,
+                arity,
+                ref pid,
+                ref free_vars,
+                index,
+                ref uniq,
+                old_index,
+                old_uniq,
+            } => {
+                r#try!(self.writer.write_u8(NEW_FUN_EXT));
 
                 let mut buf = Vec::new();
                 {
                     let mut tmp = Encoder::new(&mut buf);
-                    try!(tmp.writer.write_u8(arity));
-                    try!(tmp.writer.write_all(uniq));
-                    try!(tmp.writer.write_u32::<BigEndian>(index));
-                    try!(tmp.writer.write_u32::<BigEndian>(free_vars.len() as u32));
-                    try!(tmp.encode_atom(module));
-                    try!(tmp.encode_fix_integer(&FixInteger::from(old_index)));
-                    try!(tmp.encode_fix_integer(&FixInteger::from(old_uniq)));
-                    try!(tmp.encode_pid(pid));
+                    r#try!(tmp.writer.write_u8(arity));
+                    r#try!(tmp.writer.write_all(uniq));
+                    r#try!(tmp.writer.write_u32::<BigEndian>(index));
+                    r#try!(tmp.writer.write_u32::<BigEndian>(free_vars.len() as u32));
+                    r#try!(tmp.encode_atom(module));
+                    r#try!(tmp.encode_fix_integer(&FixInteger::from(old_index)));
+                    r#try!(tmp.encode_fix_integer(&FixInteger::from(old_uniq)));
+                    r#try!(tmp.encode_pid(pid));
                     for v in free_vars {
-                        try!(tmp.encode_term(v));
+                        r#try!(tmp.encode_term(v));
                     }
                 }
-                try!(self.writer.write_u32::<BigEndian>(4 + buf.len() as u32));
-                try!(self.writer.write_all(&buf));
+                r#try!(self.writer.write_u32::<BigEndian>(4 + buf.len() as u32));
+                r#try!(self.writer.write_all(&buf));
             }
         }
         Ok(())
@@ -689,39 +712,37 @@ impl<W: io::Write> Encoder<W> {
 }
 
 mod aux {
-    use std::str;
+    use crate::convert::TryInto;
+    use num::bigint::Sign;
     use std::io;
     use std::ops::Range;
-    use num::bigint::Sign;
-    use convert::TryInto;
+    use std::str;
 
-    pub fn term_into_atom(t: ::Term) -> Result<::Atom, super::DecodeError> {
-        t.try_into().map_err(|t| {
-            super::DecodeError::UnexpectedType {
+    pub fn term_into_atom(t: crate::Term) -> Result<crate::Atom, super::DecodeError> {
+        t.try_into()
+            .map_err(|t| super::DecodeError::UnexpectedType {
                 value: t,
                 expected: "Atom".to_string(),
-            }
-        })
+            })
     }
-    pub fn term_into_pid(t: ::Term) -> Result<::Pid, super::DecodeError> {
-        t.try_into().map_err(|t| {
-            super::DecodeError::UnexpectedType {
+    pub fn term_into_pid(t: crate::Term) -> Result<crate::Pid, super::DecodeError> {
+        t.try_into()
+            .map_err(|t| super::DecodeError::UnexpectedType {
                 value: t,
                 expected: "Pid".to_string(),
-            }
-        })
+            })
     }
-    pub fn term_into_fix_integer(t: ::Term) -> Result<::FixInteger, super::DecodeError> {
-        t.try_into().map_err(|t| {
-            super::DecodeError::UnexpectedType {
+    pub fn term_into_fix_integer(t: crate::Term) -> Result<crate::FixInteger, super::DecodeError> {
+        t.try_into()
+            .map_err(|t| super::DecodeError::UnexpectedType {
                 value: t,
                 expected: "FixInteger".to_string(),
-            }
-        })
+            })
     }
-    pub fn term_into_ranged_integer(t: ::Term,
-                                    range: Range<i32>)
-                                    -> Result<i32, super::DecodeError> {
+    pub fn term_into_ranged_integer(
+        t: crate::Term,
+        range: Range<i32>,
+    ) -> Result<i32, super::DecodeError> {
         term_into_fix_integer(t).and_then(|i| {
             let n = i.value;
             if range.start <= n && n <= range.end {
@@ -742,7 +763,9 @@ mod aux {
     }
     pub fn latin1_bytes_to_string(buf: &[u8]) -> io::Result<String> {
         // FIXME: Supports Latin1 characters
-        str::from_utf8(buf).or_else(|e| other_error(e.to_string())).map(|s| s.to_string())
+        str::from_utf8(buf)
+            .or_else(|e| other_error(e.to_string()))
+            .map(|s| s.to_string())
     }
     pub fn byte_to_sign(b: u8) -> io::Result<Sign> {
         match b {
@@ -752,6 +775,10 @@ mod aux {
         }
     }
     pub fn sign_to_byte(sign: Sign) -> u8 {
-        if sign == Sign::Minus { 1 } else { 0 }
+        if sign == Sign::Minus {
+            1
+        } else {
+            0
+        }
     }
 }

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -1,5 +1,5 @@
-use num;
 use super::*;
+use num;
 
 pub trait TryAsRef<T> {
     fn try_as_ref(&self) -> Option<&T>;
@@ -21,7 +21,7 @@ macro_rules! impl_term_try_as_ref {
                 }
             }
         }
-    }
+    };
 }
 impl_term_try_as_ref!(Atom);
 impl_term_try_as_ref!(FixInteger);
@@ -40,12 +40,15 @@ impl_term_try_as_ref!(Tuple);
 impl_term_try_as_ref!(Map);
 
 pub trait TryInto<T> {
-    fn try_into(self) -> Result<T, Self> where Self: Sized;
+    fn try_into(self) -> Result<T, Self>
+    where
+        Self: Sized;
 }
 
 impl<T> TryInto<T> for T {
     fn try_into(self) -> Result<T, Self>
-        where Self: Sized
+    where
+        Self: Sized,
     {
         Ok(self)
     }
@@ -54,14 +57,17 @@ impl<T> TryInto<T> for T {
 macro_rules! impl_term_try_into {
     ($to:ident) => {
         impl TryInto<$to> for Term {
-            fn try_into(self) -> Result<$to, Self> where Self: Sized {
+            fn try_into(self) -> Result<$to, Self>
+            where
+                Self: Sized,
+            {
                 match self {
                     Term::$to(x) => Ok(x),
-                    _ => Err(self)
+                    _ => Err(self),
                 }
             }
         }
-    }
+    };
 }
 impl_term_try_into!(Atom);
 impl_term_try_into!(FixInteger);
@@ -139,7 +145,6 @@ impl num::traits::ToPrimitive for Term {
             Term::BigInteger(ref x) => x.to_u64(),
             _ => None,
         }
-
     }
     fn to_f64(&self) -> Option<f64> {
         match *self {
@@ -148,7 +153,6 @@ impl num::traits::ToPrimitive for Term {
             Term::Float(ref x) => x.to_f64(),
             _ => None,
         }
-
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@ extern crate libflate;
 extern crate num;
 
 use num::bigint::BigInt;
-use std::convert::From;
+use std::convert::{From, TryFrom};
 use std::fmt;
 use std::io;
 
@@ -353,16 +353,28 @@ impl fmt::Display for Float {
         write!(f, "{}", self.value)
     }
 }
-impl From<f32> for Float {
-    fn from(value: f32) -> Self {
-        Float {
-            value: value as f64,
+impl TryFrom<f32> for Float {
+    type Error = DecodeError;
+
+    fn try_from(value: f32) -> Result<Self, Self::Error> {
+        if value.is_finite() {
+            Ok(Float {
+                value: value as f64,
+            })
+        } else {
+            Err(DecodeError::NonFiniteFloat)
         }
     }
 }
-impl From<f64> for Float {
-    fn from(value: f64) -> Self {
-        Float { value: value }
+impl TryFrom<f64> for Float {
+    type Error = DecodeError;
+
+    fn try_from(value: f64) -> Result<Self, Self::Error> {
+        if value.is_finite() {
+            Ok(Float { value: value })
+        } else {
+            Err(DecodeError::NonFiniteFloat)
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,23 +28,23 @@
 //!
 //! - [Erlang External Term Format](http://erlang.org/doc/apps/erts/erl_ext_dist.html)
 //!
-extern crate num;
 extern crate byteorder;
 extern crate libflate;
+extern crate num;
 
+use num::bigint::BigInt;
+use std::convert::From;
 use std::fmt;
 use std::io;
-use std::convert::From;
-use num::bigint::BigInt;
 
 mod codec;
 pub mod convert;
 pub mod pattern;
 
-pub use codec::EncodeResult;
-pub use codec::DecodeResult;
-pub use codec::EncodeError;
-pub use codec::DecodeError;
+pub use crate::codec::DecodeError;
+pub use crate::codec::DecodeResult;
+pub use crate::codec::EncodeError;
+pub use crate::codec::EncodeResult;
 
 /// Term.
 #[derive(Debug, PartialEq, Clone)]
@@ -77,7 +77,8 @@ impl Term {
     }
 
     pub fn as_match<'a, P>(&'a self, pattern: P) -> pattern::Result<P::Output>
-        where P: pattern::Pattern<'a>
+    where
+        P: pattern::Pattern<'a>,
     {
         pattern.try_match(self)
     }
@@ -187,14 +188,18 @@ pub struct Atom {
 }
 impl fmt::Display for Atom {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f,
-               "'{}'",
-               self.name.replace("\\", "\\\\").replace("'", "\\'"))
+        write!(
+            f,
+            "'{}'",
+            self.name.replace("\\", "\\\\").replace("'", "\\'")
+        )
     }
 }
 impl<'a> From<&'a str> for Atom {
     fn from(name: &'a str) -> Self {
-        Atom { name: name.to_string() }
+        Atom {
+            name: name.to_string(),
+        }
     }
 }
 impl From<String> for Atom {
@@ -216,22 +221,30 @@ impl fmt::Display for FixInteger {
 }
 impl From<u8> for FixInteger {
     fn from(value: u8) -> Self {
-        FixInteger { value: value as i32 }
+        FixInteger {
+            value: value as i32,
+        }
     }
 }
 impl From<i8> for FixInteger {
     fn from(value: i8) -> Self {
-        FixInteger { value: value as i32 }
+        FixInteger {
+            value: value as i32,
+        }
     }
 }
 impl From<u16> for FixInteger {
     fn from(value: u16) -> Self {
-        FixInteger { value: value as i32 }
+        FixInteger {
+            value: value as i32,
+        }
     }
 }
 impl From<i16> for FixInteger {
     fn from(value: i16) -> Self {
-        FixInteger { value: value as i32 }
+        FixInteger {
+            value: value as i32,
+        }
     }
 }
 impl From<i32> for FixInteger {
@@ -253,57 +266,79 @@ impl fmt::Display for BigInteger {
 }
 impl From<i8> for BigInteger {
     fn from(value: i8) -> Self {
-        BigInteger { value: BigInt::from(value) }
+        BigInteger {
+            value: BigInt::from(value),
+        }
     }
 }
 impl From<u8> for BigInteger {
     fn from(value: u8) -> Self {
-        BigInteger { value: BigInt::from(value) }
+        BigInteger {
+            value: BigInt::from(value),
+        }
     }
 }
 impl From<i16> for BigInteger {
     fn from(value: i16) -> Self {
-        BigInteger { value: BigInt::from(value) }
+        BigInteger {
+            value: BigInt::from(value),
+        }
     }
 }
 impl From<u16> for BigInteger {
     fn from(value: u16) -> Self {
-        BigInteger { value: BigInt::from(value) }
+        BigInteger {
+            value: BigInt::from(value),
+        }
     }
 }
 impl From<i32> for BigInteger {
     fn from(value: i32) -> Self {
-        BigInteger { value: BigInt::from(value) }
+        BigInteger {
+            value: BigInt::from(value),
+        }
     }
 }
 impl From<u32> for BigInteger {
     fn from(value: u32) -> Self {
-        BigInteger { value: BigInt::from(value) }
+        BigInteger {
+            value: BigInt::from(value),
+        }
     }
 }
 impl From<i64> for BigInteger {
     fn from(value: i64) -> Self {
-        BigInteger { value: BigInt::from(value) }
+        BigInteger {
+            value: BigInt::from(value),
+        }
     }
 }
 impl From<u64> for BigInteger {
     fn from(value: u64) -> Self {
-        BigInteger { value: BigInt::from(value) }
+        BigInteger {
+            value: BigInt::from(value),
+        }
     }
 }
 impl From<isize> for BigInteger {
     fn from(value: isize) -> Self {
-        BigInteger { value: BigInt::from(value) }
+        BigInteger {
+            value: BigInt::from(value),
+        }
     }
 }
 impl From<usize> for BigInteger {
     fn from(value: usize) -> Self {
-        BigInteger { value: BigInt::from(value) }
+        BigInteger {
+            value: BigInt::from(value),
+        }
     }
 }
 impl<'a> From<&'a FixInteger> for BigInteger {
     fn from(i: &FixInteger) -> Self {
-        BigInteger { value: BigInt::from(i.value) }
+        BigInteger {
+            value: BigInt::from(i.value),
+        }
     }
 }
 
@@ -320,7 +355,9 @@ impl fmt::Display for Float {
 }
 impl From<f32> for Float {
     fn from(value: f32) -> Self {
-        Float { value: value as f64 }
+        Float {
+            value: value as f64,
+        }
     }
 }
 impl From<f64> for Float {
@@ -339,7 +376,8 @@ pub struct Pid {
 }
 impl Pid {
     pub fn new<T>(node: T, id: u32, serial: u32, creation: u8) -> Self
-        where Atom: From<T>
+    where
+        Atom: From<T>,
     {
         Pid {
             node: Atom::from(node),
@@ -397,9 +435,9 @@ pub struct Reference {
 }
 impl fmt::Display for Reference {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        try!(write!(f, "#Ref<{}", self.node));
+        r#try!(write!(f, "#Ref<{}", self.node));
         for n in &self.id {
-            try!(write!(f, ".{}", n));
+            r#try!(write!(f, ".{}", n));
         }
         write!(f, ">")
     }
@@ -471,10 +509,18 @@ pub enum InternalFun {
 impl fmt::Display for InternalFun {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            InternalFun::Old { ref module, index, uniq, .. } => {
-                write!(f, "#Fun<{}.{}.{}>", module, index, uniq)
-            }
-            InternalFun::New { ref module, index, uniq, .. } => {
+            InternalFun::Old {
+                ref module,
+                index,
+                uniq,
+                ..
+            } => write!(f, "#Fun<{}.{}.{}>", module, index, uniq),
+            InternalFun::New {
+                ref module,
+                index,
+                uniq,
+                ..
+            } => {
                 use num::bigint::Sign;
                 let uniq = BigInt::from_bytes_be(Sign::Plus, &uniq);
                 write!(f, "#Fun<{}.{}.{}>", module, index, uniq)
@@ -490,20 +536,22 @@ pub struct Binary {
 }
 impl fmt::Display for Binary {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        try!(write!(f, "<<"));
+        r#try!(write!(f, "<<"));
         for (i, b) in self.bytes.iter().enumerate() {
             if i != 0 {
-                try!(write!(f, ","));
+                r#try!(write!(f, ","));
             }
-            try!(write!(f, "{}", b));
+            r#try!(write!(f, "{}", b));
         }
-        try!(write!(f, ">>"));
+        r#try!(write!(f, ">>"));
         Ok(())
     }
 }
 impl<'a> From<(&'a [u8])> for Binary {
     fn from(bytes: &'a [u8]) -> Self {
-        Binary { bytes: Vec::from(bytes) }
+        Binary {
+            bytes: Vec::from(bytes),
+        }
     }
 }
 impl From<Vec<u8>> for Binary {
@@ -520,21 +568,21 @@ pub struct BitBinary {
 }
 impl fmt::Display for BitBinary {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        try!(write!(f, "<<"));
+        r#try!(write!(f, "<<"));
         for (i, b) in self.bytes.iter().enumerate() {
             if i == self.bytes.len() - 1 && self.tail_bits_size == 0 {
                 break;
             }
             if i != 0 {
-                try!(write!(f, ","));
+                r#try!(write!(f, ","));
             }
             if i == self.bytes.len() - 1 && self.tail_bits_size < 8 {
-                try!(write!(f, "{}:{}", b, self.tail_bits_size));
+                r#try!(write!(f, "{}:{}", b, self.tail_bits_size));
             } else {
-                try!(write!(f, "{}", b));
+                r#try!(write!(f, "{}", b));
             }
         }
-        try!(write!(f, ">>"));
+        r#try!(write!(f, ">>"));
         Ok(())
     }
 }
@@ -563,7 +611,9 @@ pub struct List {
 impl List {
     /// Returns a nil value (i.e., an empty list).
     pub fn nil() -> Self {
-        List { elements: Vec::new() }
+        List {
+            elements: Vec::new(),
+        }
     }
 
     /// Returns `true` if it is nil value, otherwise `false`.
@@ -573,14 +623,14 @@ impl List {
 }
 impl fmt::Display for List {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        try!(write!(f, "["));
+        r#try!(write!(f, "["));
         for (i, x) in self.elements.iter().enumerate() {
             if i != 0 {
-                try!(write!(f, ","));
+                r#try!(write!(f, ","));
             }
-            try!(write!(f, "{}", x));
+            r#try!(write!(f, "{}", x));
         }
-        try!(write!(f, "]"));
+        r#try!(write!(f, "]"));
         Ok(())
     }
 }
@@ -598,15 +648,15 @@ pub struct ImproperList {
 }
 impl fmt::Display for ImproperList {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        try!(write!(f, "["));
+        r#try!(write!(f, "["));
         for (i, x) in self.elements.iter().enumerate() {
             if i != 0 {
-                try!(write!(f, ","));
+                r#try!(write!(f, ","));
             }
-            try!(write!(f, "{}", x));
+            r#try!(write!(f, "{}", x));
         }
-        try!(write!(f, "|{}", self.last));
-        try!(write!(f, "]"));
+        r#try!(write!(f, "|{}", self.last));
+        r#try!(write!(f, "]"));
         Ok(())
     }
 }
@@ -626,19 +676,21 @@ pub struct Tuple {
 }
 impl Tuple {
     pub fn nil() -> Self {
-        Tuple { elements: Vec::new() }
+        Tuple {
+            elements: Vec::new(),
+        }
     }
 }
 impl fmt::Display for Tuple {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        try!(write!(f, "{{"));
+        r#try!(write!(f, "{{"));
         for (i, x) in self.elements.iter().enumerate() {
             if i != 0 {
-                try!(write!(f, ","));
+                r#try!(write!(f, ","));
             }
-            try!(write!(f, "{}", x));
+            r#try!(write!(f, "{}", x));
         }
-        try!(write!(f, "}}"));
+        r#try!(write!(f, "}}"));
         Ok(())
     }
 }
@@ -655,14 +707,14 @@ pub struct Map {
 }
 impl fmt::Display for Map {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        try!(write!(f, "#{{"));
+        r#try!(write!(f, "#{{"));
         for (i, &(ref k, ref v)) in self.entries.iter().enumerate() {
             if i != 0 {
-                try!(write!(f, ","));
+                r#try!(write!(f, ","));
             }
-            try!(write!(f, "{}=>{}", k, v));
+            r#try!(write!(f, "{}=>{}", k, v));
         }
-        try!(write!(f, "}}"));
+        r#try!(write!(f, "}}"));
         Ok(())
     }
 }
@@ -675,22 +727,26 @@ impl From<Vec<(Term, Term)>> for Map {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use pattern::any;
-    use pattern::U8;
+    use crate::pattern::any;
+    use crate::pattern::U8;
 
     #[test]
     fn it_works() {
         let t = Term::from(Atom::from("hoge"));
         t.as_match("hoge").unwrap();
 
-        let t = Term::from(Tuple::from(vec![Term::from(Atom::from("foo")),
-                                            Term::from(Atom::from("bar"))]));
+        let t = Term::from(Tuple::from(vec![
+            Term::from(Atom::from("foo")),
+            Term::from(Atom::from("bar")),
+        ]));
         let (_, v) = t.as_match(("foo", any::<Atom>())).unwrap();
         assert_eq!("bar", v.name);
 
-        let t = Term::from(Tuple::from(vec![Term::from(Atom::from("foo")),
-                             Term::from(Atom::from("bar")),
-                             Term::from(Tuple::from(vec![Term::from(Atom::from("bar"))]))]));
+        let t = Term::from(Tuple::from(vec![
+            Term::from(Atom::from("foo")),
+            Term::from(Atom::from("bar")),
+            Term::from(Tuple::from(vec![Term::from(Atom::from("bar"))])),
+        ]));
         assert!(t.as_match(("foo", "bar", "baz")).is_err());
 
         let t = Term::from(FixInteger::from(8));

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,9 +1,9 @@
 extern crate eetf;
 extern crate num;
 
-use std::io::Cursor;
-use eetf::*;
 use eetf::convert::TryInto;
+use eetf::*;
+use std::io::Cursor;
 
 #[test]
 fn atom_test() {
@@ -13,18 +13,28 @@ fn atom_test() {
     assert_eq!(r#"'fo\\o'"#, Atom::from(r#"fo\o"#).to_string());
 
     // Decode
-    assert_eq!(Ok(Atom::from("foo")),
-               decode(&[131, 100, 0, 3, 102, 111, 111]).try_into()); // ATOM_EXT
-    assert_eq!(Ok(Atom::from("foo")),
-               decode(&[131, 115, 3, 102, 111, 111]).try_into()); // SMALL_ATOM_EXT
-    assert_eq!(Ok(Atom::from("foo")),
-               decode(&[131, 118, 0, 3, 102, 111, 111]).try_into()); // ATOM_UTF8_EXT
-    assert_eq!(Ok(Atom::from("foo")),
-               decode(&[131, 119, 3, 102, 111, 111]).try_into()); // SMALL_ATOM_UTF8_EXT
+    assert_eq!(
+        Ok(Atom::from("foo")),
+        decode(&[131, 100, 0, 3, 102, 111, 111]).try_into()
+    ); // ATOM_EXT
+    assert_eq!(
+        Ok(Atom::from("foo")),
+        decode(&[131, 115, 3, 102, 111, 111]).try_into()
+    ); // SMALL_ATOM_EXT
+    assert_eq!(
+        Ok(Atom::from("foo")),
+        decode(&[131, 118, 0, 3, 102, 111, 111]).try_into()
+    ); // ATOM_UTF8_EXT
+    assert_eq!(
+        Ok(Atom::from("foo")),
+        decode(&[131, 119, 3, 102, 111, 111]).try_into()
+    ); // SMALL_ATOM_UTF8_EXT
 
     // Encode
-    assert_eq!(vec![131, 100, 0, 3, 102, 111, 111],
-               encode(Term::from(Atom::from("foo"))));
+    assert_eq!(
+        vec![131, 100, 0, 3, 102, 111, 111],
+        encode(Term::from(Atom::from("foo")))
+    );
 }
 
 #[test]
@@ -37,31 +47,53 @@ fn integer_test() {
 
     // Decode
     assert_eq!(Ok(FixInteger::from(10)), decode(&[131, 97, 10]).try_into()); // SMALL_INTEGER_EXT
-    assert_eq!(Ok(FixInteger::from(1000)),
-               decode(&[131, 98, 0, 0, 3, 232]).try_into()); // INTEGER_EXT
-    assert_eq!(Ok(FixInteger::from(-1000)),
-               decode(&[131, 98, 255, 255, 252, 24]).try_into()); // INTEGER_EXT
-    assert_eq!(Ok(BigInteger::from(0)),
-               decode(&[131, 110, 1, 0, 0]).try_into()); // SMALL_BIG_EXT
-    assert_eq!(Ok(BigInteger::from(513)),
-               decode(&[131, 110, 2, 0, 1, 2]).try_into()); // SMALL_BIG_EXT
-    assert_eq!(Ok(BigInteger::from(-513)),
-               decode(&[131, 110, 2, 1, 1, 2]).try_into()); // SMALL_BIG_EXT
-    assert_eq!(Ok(BigInteger::from(513)),
-               decode(&[131, 111, 0, 0, 0, 2, 0, 1, 2]).try_into()); // LARGE_BIG_EXT
+    assert_eq!(
+        Ok(FixInteger::from(1000)),
+        decode(&[131, 98, 0, 0, 3, 232]).try_into()
+    ); // INTEGER_EXT
+    assert_eq!(
+        Ok(FixInteger::from(-1000)),
+        decode(&[131, 98, 255, 255, 252, 24]).try_into()
+    ); // INTEGER_EXT
+    assert_eq!(
+        Ok(BigInteger::from(0)),
+        decode(&[131, 110, 1, 0, 0]).try_into()
+    ); // SMALL_BIG_EXT
+    assert_eq!(
+        Ok(BigInteger::from(513)),
+        decode(&[131, 110, 2, 0, 1, 2]).try_into()
+    ); // SMALL_BIG_EXT
+    assert_eq!(
+        Ok(BigInteger::from(-513)),
+        decode(&[131, 110, 2, 1, 1, 2]).try_into()
+    ); // SMALL_BIG_EXT
+    assert_eq!(
+        Ok(BigInteger::from(513)),
+        decode(&[131, 111, 0, 0, 0, 2, 0, 1, 2]).try_into()
+    ); // LARGE_BIG_EXT
 
     // Encode
     assert_eq!(vec![131, 97, 0], encode(Term::from(FixInteger::from(0))));
-    assert_eq!(vec![131, 98, 255, 255, 255, 255],
-               encode(Term::from(FixInteger::from(-1))));
-    assert_eq!(vec![131, 98, 0, 0, 3, 232],
-               encode(Term::from(FixInteger::from(1000))));
-    assert_eq!(vec![131, 110, 1, 0, 0],
-               encode(Term::from(BigInteger::from(0))));
-    assert_eq!(vec![131, 110, 1, 1, 10],
-               encode(Term::from(BigInteger::from(-10))));
-    assert_eq!(vec![131, 110, 5, 0, 0, 228, 11, 84, 2],
-               encode(Term::from(BigInteger::from(10000000000u64))));
+    assert_eq!(
+        vec![131, 98, 255, 255, 255, 255],
+        encode(Term::from(FixInteger::from(-1)))
+    );
+    assert_eq!(
+        vec![131, 98, 0, 0, 3, 232],
+        encode(Term::from(FixInteger::from(1000)))
+    );
+    assert_eq!(
+        vec![131, 110, 1, 0, 0],
+        encode(Term::from(BigInteger::from(0)))
+    );
+    assert_eq!(
+        vec![131, 110, 1, 1, 10],
+        encode(Term::from(BigInteger::from(-10)))
+    );
+    assert_eq!(
+        vec![131, 110, 5, 0, 0, 228, 11, 84, 2],
+        encode(Term::from(BigInteger::from(10000000000u64)))
+    );
 }
 
 #[test]
@@ -72,92 +104,137 @@ fn float_test() {
     assert_eq!("-123.4", Float::from(-123.4).to_string());
 
     // Decode
-    assert_eq!(Ok(Float::from("1.23".parse::<f32>().unwrap() as f64)),
-               decode(&[131, 99, 49, 46, 50, 50, 57, 57, 57, 57, 57, 57, 57, 57, 57, 57, 57, 57,
-                        57, 57, 56, 50, 50, 52, 101, 43, 48, 48, 0, 0, 0, 0, 0])
-                   .try_into()); // FLOAT_EXT
+    assert_eq!(
+        Ok(Float::from("1.23".parse::<f32>().unwrap() as f64)),
+        decode(&[
+            131, 99, 49, 46, 50, 50, 57, 57, 57, 57, 57, 57, 57, 57, 57, 57, 57, 57, 57, 57, 56,
+            50, 50, 52, 101, 43, 48, 48, 0, 0, 0, 0, 0
+        ])
+        .try_into()
+    ); // FLOAT_EXT
 
-    assert_eq!(Ok(Float::from(123.456)),
-               // NEW_FLOAT_EXT
-               decode(&[131, 70, 64, 94, 221, 47, 26, 159, 190, 119]).try_into());
-    assert_eq!(Ok(Float::from(-123.456)),
-               // NEW_FLOAT_EXT
-               decode(&[131, 70, 192, 94, 221, 47, 26, 159, 190, 119]).try_into());
+    assert_eq!(
+        Ok(Float::from(123.456)),
+        // NEW_FLOAT_EXT
+        decode(&[131, 70, 64, 94, 221, 47, 26, 159, 190, 119]).try_into()
+    );
+    assert_eq!(
+        Ok(Float::from(-123.456)),
+        // NEW_FLOAT_EXT
+        decode(&[131, 70, 192, 94, 221, 47, 26, 159, 190, 119]).try_into()
+    );
     // Encode
-    assert_eq!(vec![131, 70, 64, 94, 221, 47, 26, 159, 190, 119],
-               encode(Term::from(Float::from(123.456))));
+    assert_eq!(
+        vec![131, 70, 64, 94, 221, 47, 26, 159, 190, 119],
+        encode(Term::from(Float::from(123.456)))
+    );
 }
 
 #[test]
 fn pid_test() {
     // Display
-    assert_eq!(r#"<'nonode@nohost'.1.2>"#,
-               Pid::from(("nonode@nohost", 1, 2)).to_string());
+    assert_eq!(
+        r#"<'nonode@nohost'.1.2>"#,
+        Pid::from(("nonode@nohost", 1, 2)).to_string()
+    );
 
     // Decode
-    assert_eq!(Ok(Pid::from(("nonode@nohost", 49, 0))),
-               decode(&[131, 103, 100, 0, 13, 110, 111, 110, 111, 100, 101, 64, 110, 111, 104,
-                        111, 115, 116, 0, 0, 0, 49, 0, 0, 0, 0, 0])
-                   .try_into()); // PID_EXT
+    assert_eq!(
+        Ok(Pid::from(("nonode@nohost", 49, 0))),
+        decode(&[
+            131, 103, 100, 0, 13, 110, 111, 110, 111, 100, 101, 64, 110, 111, 104, 111, 115, 116,
+            0, 0, 0, 49, 0, 0, 0, 0, 0
+        ])
+        .try_into()
+    ); // PID_EXT
 
     // Encode
-    assert_eq!(vec![131, 103, 100, 0, 13, 110, 111, 110, 111, 100, 101, 64, 110, 111, 104, 111,
-                    115, 116, 0, 0, 0, 49, 0, 0, 0, 0, 0],
-               encode(Term::from(Pid::from(("nonode@nohost", 49, 0)))));
+    assert_eq!(
+        vec![
+            131, 103, 100, 0, 13, 110, 111, 110, 111, 100, 101, 64, 110, 111, 104, 111, 115, 116,
+            0, 0, 0, 49, 0, 0, 0, 0, 0
+        ],
+        encode(Term::from(Pid::from(("nonode@nohost", 49, 0))))
+    );
 }
 
 #[test]
 fn port_test() {
     // Display
-    assert_eq!(r#"#Port<'nonode@nohost'.1>"#,
-               Port::from(("nonode@nohost", 1)).to_string());
+    assert_eq!(
+        r#"#Port<'nonode@nohost'.1>"#,
+        Port::from(("nonode@nohost", 1)).to_string()
+    );
 
     // Decode
-    assert_eq!(Ok(Port::from(("nonode@nohost", 366))),
-               decode(&[131, 102, 100, 0, 13, 110, 111, 110, 111, 100, 101, 64, 110, 111, 104,
-                        111, 115, 116, 0, 0, 1, 110, 0])
-                   .try_into()); // PORT_EXT
+    assert_eq!(
+        Ok(Port::from(("nonode@nohost", 366))),
+        decode(&[
+            131, 102, 100, 0, 13, 110, 111, 110, 111, 100, 101, 64, 110, 111, 104, 111, 115, 116,
+            0, 0, 1, 110, 0
+        ])
+        .try_into()
+    ); // PORT_EXT
 
     // Encode
-    assert_eq!(vec![131, 102, 100, 0, 13, 110, 111, 110, 111, 100, 101, 64, 110, 111, 104, 111,
-                    115, 116, 0, 0, 1, 110, 0],
-               encode(Term::from(Port::from(("nonode@nohost", 366)))));
+    assert_eq!(
+        vec![
+            131, 102, 100, 0, 13, 110, 111, 110, 111, 100, 101, 64, 110, 111, 104, 111, 115, 116,
+            0, 0, 1, 110, 0
+        ],
+        encode(Term::from(Port::from(("nonode@nohost", 366))))
+    );
 }
 
 #[test]
 fn reference_test() {
     // Display
-    assert_eq!(r#"#Ref<'nonode@nohost'.1>"#,
-               Reference::from(("nonode@nohost", 1)).to_string());
+    assert_eq!(
+        r#"#Ref<'nonode@nohost'.1>"#,
+        Reference::from(("nonode@nohost", 1)).to_string()
+    );
 
     // Decode
-    assert_eq!(Ok(Reference::from(("nonode@nohost", vec![138016, 262145, 0]))),
-               decode(&[131, 114, 0, 3, 100, 0, 13, 110, 111, 110, 111, 100, 101, 64, 110, 111,
-                        104, 111, 115, 116, 0, 0, 2, 27, 32, 0, 4, 0, 1, 0, 0, 0, 0])
-                   .try_into()); // NEW_REFERENCE_EXT
-    assert_eq!(Ok(Reference::from(("foo", vec![2]))),
-               // NEW_REFERENCE_EXT
-               decode(&[131, 101, 115, 3, 102, 111, 111, 0, 0, 0, 2, 0]).try_into());
+    assert_eq!(
+        Ok(Reference::from(("nonode@nohost", vec![138016, 262145, 0]))),
+        decode(&[
+            131, 114, 0, 3, 100, 0, 13, 110, 111, 110, 111, 100, 101, 64, 110, 111, 104, 111, 115,
+            116, 0, 0, 2, 27, 32, 0, 4, 0, 1, 0, 0, 0, 0
+        ])
+        .try_into()
+    ); // NEW_REFERENCE_EXT
+    assert_eq!(
+        Ok(Reference::from(("foo", vec![2]))),
+        // NEW_REFERENCE_EXT
+        decode(&[131, 101, 115, 3, 102, 111, 111, 0, 0, 0, 2, 0]).try_into()
+    );
 
     // Encode
-    assert_eq!(vec![131, 114, 0, 1, 100, 0, 3, 102, 111, 111, 0, 0, 0, 0, 123],
-               encode(Term::from(Reference::from(("foo", 123)))));
+    assert_eq!(
+        vec![131, 114, 0, 1, 100, 0, 3, 102, 111, 111, 0, 0, 0, 0, 123],
+        encode(Term::from(Reference::from(("foo", 123))))
+    );
 }
 
 #[test]
 fn external_fun_test() {
     // Display
-    assert_eq!(r#"fun 'foo':'bar'/3"#,
-               ExternalFun::from(("foo", "bar", 3)).to_string());
+    assert_eq!(
+        r#"fun 'foo':'bar'/3"#,
+        ExternalFun::from(("foo", "bar", 3)).to_string()
+    );
 
     // Decode
-    assert_eq!(Ok(ExternalFun::from(("foo", "bar", 3))),
-               decode(&[131, 113, 100, 0, 3, 102, 111, 111, 100, 0, 3, 98, 97, 114, 97, 3])
-                   .try_into());
+    assert_eq!(
+        Ok(ExternalFun::from(("foo", "bar", 3))),
+        decode(&[131, 113, 100, 0, 3, 102, 111, 111, 100, 0, 3, 98, 97, 114, 97, 3]).try_into()
+    );
 
     // Encode
-    assert_eq!(vec![131, 113, 100, 0, 3, 102, 111, 111, 100, 0, 3, 98, 97, 114, 97, 3],
-               encode(Term::from(ExternalFun::from(("foo", "bar", 3)))));
+    assert_eq!(
+        vec![131, 113, 100, 0, 3, 102, 111, 111, 100, 0, 3, 98, 97, 114, 97, 3],
+        encode(Term::from(ExternalFun::from(("foo", "bar", 3))))
+    );
 }
 
 #[test]
@@ -167,15 +244,19 @@ fn internal_fun_test() {
         arity: 1,
         pid: Pid::from(("nonode@nohost", 36, 0)),
         index: 0,
-        uniq: [115, 60, 203, 97, 151, 228, 98, 75, 71, 169, 49, 166, 34, 126, 65, 11],
+        uniq: [
+            115, 60, 203, 97, 151, 228, 98, 75, 71, 169, 49, 166, 34, 126, 65, 11,
+        ],
         old_index: 0,
         old_uniq: 60417627,
         free_vars: vec![Term::from(FixInteger::from(10))],
     };
-    let bytes = [131, 112, 0, 0, 0, 68, 1, 115, 60, 203, 97, 151, 228, 98, 75, 71, 169, 49, 166,
-                 34, 126, 65, 11, 0, 0, 0, 0, 0, 0, 0, 1, 100, 0, 1, 97, 97, 0, 98, 3, 153, 230,
-                 91, 103, 100, 0, 13, 110, 111, 110, 111, 100, 101, 64, 110, 111, 104, 111, 115,
-                 116, 0, 0, 0, 36, 0, 0, 0, 0, 0, 97, 10];
+    let bytes = [
+        131, 112, 0, 0, 0, 68, 1, 115, 60, 203, 97, 151, 228, 98, 75, 71, 169, 49, 166, 34, 126,
+        65, 11, 0, 0, 0, 0, 0, 0, 0, 1, 100, 0, 1, 97, 97, 0, 98, 3, 153, 230, 91, 103, 100, 0, 13,
+        110, 111, 110, 111, 100, 101, 64, 110, 111, 104, 111, 115, 116, 0, 0, 0, 36, 0, 0, 0, 0, 0,
+        97, 10,
+    ];
     // Decode
     assert_eq!(Ok(term.clone()), decode(&bytes).try_into());
 
@@ -189,12 +270,16 @@ fn binary_test() {
     assert_eq!("<<1,2,3>>", Binary::from(vec![1, 2, 3]).to_string());
 
     // Decode
-    assert_eq!(Ok(Binary::from(vec![1, 2, 3])),
-               decode(&[131, 109, 0, 0, 0, 3, 1, 2, 3]).try_into());
+    assert_eq!(
+        Ok(Binary::from(vec![1, 2, 3])),
+        decode(&[131, 109, 0, 0, 0, 3, 1, 2, 3]).try_into()
+    );
 
     // Encode
-    assert_eq!(vec![131, 109, 0, 0, 0, 3, 1, 2, 3],
-               encode(Term::from(Binary::from(vec![1, 2, 3]))));
+    assert_eq!(
+        vec![131, 109, 0, 0, 0, 3, 1, 2, 3],
+        encode(Term::from(Binary::from(vec![1, 2, 3])))
+    );
 }
 
 #[test]
@@ -202,85 +287,138 @@ fn bit_binary_test() {
     // Display
     assert_eq!("<<1,2,3>>", BitBinary::from((vec![1, 2, 3], 8)).to_string());
     assert_eq!("<<1,2>>", BitBinary::from((vec![1, 2, 3], 0)).to_string());
-    assert_eq!("<<1,2,3:5>>",
-               BitBinary::from((vec![1, 2, 3], 5)).to_string());
+    assert_eq!(
+        "<<1,2,3:5>>",
+        BitBinary::from((vec![1, 2, 3], 5)).to_string()
+    );
 
     // Decode
-    assert_eq!(Ok(BitBinary::from((vec![1, 2, 3], 5))),
-               decode(&[131, 77, 0, 0, 0, 3, 5, 1, 2, 24]).try_into());
+    assert_eq!(
+        Ok(BitBinary::from((vec![1, 2, 3], 5))),
+        decode(&[131, 77, 0, 0, 0, 3, 5, 1, 2, 24]).try_into()
+    );
 
     // Encode
-    assert_eq!(vec![131, 77, 0, 0, 0, 3, 5, 1, 2, 24],
-               encode(Term::from(BitBinary::from((vec![1, 2, 3], 5)))));
+    assert_eq!(
+        vec![131, 77, 0, 0, 0, 3, 5, 1, 2, 24],
+        encode(Term::from(BitBinary::from((vec![1, 2, 3], 5))))
+    );
 }
 
 #[test]
 fn list_test() {
     // Display
-    assert_eq!("['a',1]",
-               List::from(vec![Term::from(Atom::from("a")), Term::from(FixInteger::from(1))])
-                   .to_string());
+    assert_eq!(
+        "['a',1]",
+        List::from(vec![
+            Term::from(Atom::from("a")),
+            Term::from(FixInteger::from(1))
+        ])
+        .to_string()
+    );
     assert_eq!("[]", List::nil().to_string());
 
     // Decode
     assert_eq!(Ok(List::nil()), decode(&[131, 106]).try_into()); // NIL_EXT
-    assert_eq!(Ok(List::from(vec![Term::from(FixInteger::from(1)),
-                                  Term::from(FixInteger::from(2))])),
-               decode(&[131, 107, 0, 2, 1, 2]).try_into()); // STRING_EXT
-    assert_eq!(Ok(List::from(vec![Term::from(Atom::from("a"))])),
-               decode(&[131, 108, 0, 0, 0, 1, 100, 0, 1, 97, 106]).try_into());
+    assert_eq!(
+        Ok(List::from(vec![
+            Term::from(FixInteger::from(1)),
+            Term::from(FixInteger::from(2))
+        ])),
+        decode(&[131, 107, 0, 2, 1, 2]).try_into()
+    ); // STRING_EXT
+    assert_eq!(
+        Ok(List::from(vec![Term::from(Atom::from("a"))])),
+        decode(&[131, 108, 0, 0, 0, 1, 100, 0, 1, 97, 106]).try_into()
+    );
 
     // Encode
     assert_eq!(vec![131, 106], encode(Term::from(List::nil())));
-    assert_eq!(vec![131, 107, 0, 2, 1, 2],
-               encode(Term::from(List::from(vec![Term::from(FixInteger::from(1)),
-                                                 Term::from(FixInteger::from(2))]))));
-    assert_eq!(vec![131, 108, 0, 0, 0, 1, 100, 0, 1, 97, 106],
-               encode(Term::from(List::from(vec![Term::from(Atom::from("a"))]))));
+    assert_eq!(
+        vec![131, 107, 0, 2, 1, 2],
+        encode(Term::from(List::from(vec![
+            Term::from(FixInteger::from(1)),
+            Term::from(FixInteger::from(2))
+        ])))
+    );
+    assert_eq!(
+        vec![131, 108, 0, 0, 0, 1, 100, 0, 1, 97, 106],
+        encode(Term::from(List::from(vec![Term::from(Atom::from("a"))])))
+    );
 }
 
 #[test]
 fn improper_list_test() {
     // Display
-    assert_eq!("[0,'a'|1]",
-               ImproperList::from((vec![Term::from(FixInteger::from(0)),
-                                        Term::from(Atom::from("a"))],
-                                   Term::from(FixInteger::from(1))))
-                   .to_string());
+    assert_eq!(
+        "[0,'a'|1]",
+        ImproperList::from((
+            vec![Term::from(FixInteger::from(0)), Term::from(Atom::from("a"))],
+            Term::from(FixInteger::from(1))
+        ))
+        .to_string()
+    );
 
     // Decode
-    assert_eq!(Ok(ImproperList::from((vec![Term::from(Atom::from("a"))],
-                                      Term::from(FixInteger::from(1))))),
-               decode(&[131, 108, 0, 0, 0, 1, 100, 0, 1, 97, 97, 1]).try_into());
+    assert_eq!(
+        Ok(ImproperList::from((
+            vec![Term::from(Atom::from("a"))],
+            Term::from(FixInteger::from(1))
+        ))),
+        decode(&[131, 108, 0, 0, 0, 1, 100, 0, 1, 97, 97, 1]).try_into()
+    );
 
     // Encode
-    assert_eq!(vec![131, 108, 0, 0, 0, 1, 100, 0, 1, 97, 97, 1],
-               encode(Term::from(ImproperList::from((vec![Term::from(Atom::from("a"))],
-                                                     Term::from(FixInteger::from(1)))))));
+    assert_eq!(
+        vec![131, 108, 0, 0, 0, 1, 100, 0, 1, 97, 97, 1],
+        encode(Term::from(ImproperList::from((
+            vec![Term::from(Atom::from("a"))],
+            Term::from(FixInteger::from(1))
+        ))))
+    );
 }
 
 #[test]
 fn tuple_test() {
     // Display
-    assert_eq!("{'a',1}",
-               Tuple::from(vec![Term::from(Atom::from("a")), Term::from(FixInteger::from(1))])
-                   .to_string());
+    assert_eq!(
+        "{'a',1}",
+        Tuple::from(vec![
+            Term::from(Atom::from("a")),
+            Term::from(FixInteger::from(1))
+        ])
+        .to_string()
+    );
     assert_eq!("{}", Tuple::from(vec![]).to_string());
 
     // Decode
-    assert_eq!(Ok(Tuple::from(vec![Term::from(Atom::from("a")), Term::from(FixInteger::from(1))])),
-               decode(&[131, 104, 2, 100, 0, 1, 97, 97, 1]).try_into());
+    assert_eq!(
+        Ok(Tuple::from(vec![
+            Term::from(Atom::from("a")),
+            Term::from(FixInteger::from(1))
+        ])),
+        decode(&[131, 104, 2, 100, 0, 1, 97, 97, 1]).try_into()
+    );
 
     // Encode
-    assert_eq!(vec![131, 104, 2, 100, 0, 1, 97, 97, 1],
-               encode(Term::from(Tuple::from(vec![Term::from(Atom::from("a")),
-                                                  Term::from(FixInteger::from(1))]))));
+    assert_eq!(
+        vec![131, 104, 2, 100, 0, 1, 97, 97, 1],
+        encode(Term::from(Tuple::from(vec![
+            Term::from(Atom::from("a")),
+            Term::from(FixInteger::from(1))
+        ])))
+    );
 }
 
 #[test]
 fn map_test() {
-    let map = Map::from(vec![(Term::from(FixInteger::from(1)), Term::from(FixInteger::from(2))),
-                             (Term::from(Atom::from("a")), Term::from(Atom::from("b")))]);
+    let map = Map::from(vec![
+        (
+            Term::from(FixInteger::from(1)),
+            Term::from(FixInteger::from(2)),
+        ),
+        (Term::from(Atom::from("a")), Term::from(Atom::from("b"))),
+    ]);
 
     // Display
     assert_eq!("#{1=>2,'a'=>'b'}", map.to_string());
@@ -288,46 +426,51 @@ fn map_test() {
     assert_eq!("#{}", Map::from(vec![]).to_string());
 
     // Decode
-    assert_eq!(Ok(map.clone()),
-               decode(&[131, 116, 0, 0, 0, 2, 97, 1, 97, 2, 100, 0, 1, 97, 100, 0, 1, 98])
-                   .try_into());
+    assert_eq!(
+        Ok(map.clone()),
+        decode(&[131, 116, 0, 0, 0, 2, 97, 1, 97, 2, 100, 0, 1, 97, 100, 0, 1, 98]).try_into()
+    );
 
     // Encode
-    assert_eq!(vec![131, 116, 0, 0, 0, 2, 97, 1, 97, 2, 100, 0, 1, 97, 100, 0, 1, 98],
-               encode(Term::from(map)));
+    assert_eq!(
+        vec![131, 116, 0, 0, 0, 2, 97, 1, 97, 2, 100, 0, 1, 97, 100, 0, 1, 98],
+        encode(Term::from(map))
+    );
 }
 
 #[test]
 fn compressed_term_test() {
     // Decode
-    assert_eq!(Ok(List::from((1..257)
-                   .map(|i| Term::from(FixInteger::from(i)))
-                   .collect::<Vec<_>>())),
-               decode(&[131, 80, 0, 0, 2, 9, 120, 218, 21, 210, 3, 187, 16, 6, 0, 0, 192, 151,
-                        237, 150, 173, 101, 219, 54, 182, 236, 186, 220, 235, 101, 219, 182,
-                        237, 150, 93, 219, 178, 109, 219, 182, 237, 175, 251, 13, 23, 20, 16,
-                        16, 44, 64, 48, 193, 133, 16, 82, 40, 161, 133, 17, 86, 56, 225, 69, 16,
-                        81, 36, 145, 69, 17, 85, 52, 209, 197, 16, 211, 31, 98, 137, 45, 142,
-                        184, 226, 137, 47, 129, 132, 18, 73, 44, 137, 164, 146, 73, 46, 133,
-                        148, 82, 249, 83, 106, 105, 164, 149, 78, 122, 25, 100, 148, 73, 102,
-                        89, 100, 149, 77, 118, 57, 228, 148, 75, 110, 121, 228, 149, 79, 126, 5,
-                        20, 84, 72, 97, 69, 20, 85, 76, 113, 37, 148, 84, 74, 105, 101, 148, 85,
-                        78, 121, 21, 84, 84, 201, 95, 254, 86, 89, 21, 85, 85, 83, 93, 13, 53,
-                        213, 82, 91, 29, 117, 213, 83, 95, 3, 13, 209, 72, 99, 77, 52, 213, 76,
-                        115, 45, 180, 20, 168, 149, 32, 173, 181, 209, 86, 59, 237, 117, 208,
-                        81, 39, 157, 117, 209, 85, 55, 221, 245, 208, 83, 47, 189, 245, 209, 87,
-                        63, 253, 13, 48, 208, 32, 131, 13, 49, 212, 48, 195, 141, 48, 210, 40,
-                        163, 141, 49, 214, 56, 227, 77, 48, 209, 36, 147, 77, 49, 213, 52, 211,
-                        205, 48, 211, 44, 179, 205, 49, 215, 60, 243, 45, 176, 208, 34, 255, 88,
-                        108, 137, 165, 150, 89, 110, 133, 149, 86, 89, 109, 141, 181, 214, 89,
-                        111, 131, 141, 254, 245, 159, 255, 109, 178, 217, 22, 91, 109, 179, 221,
-                        14, 59, 237, 178, 219, 30, 123, 237, 179, 223, 1, 7, 29, 114, 216, 17,
-                        71, 29, 115, 220, 9, 39, 157, 114, 218, 25, 103, 157, 115, 222, 5, 23,
-                        93, 114, 217, 21, 87, 93, 115, 221, 13, 55, 221, 114, 219, 29, 119, 221,
-                        115, 223, 3, 15, 61, 242, 216, 19, 79, 61, 243, 220, 11, 47, 189, 242,
-                        218, 27, 111, 189, 243, 222, 7, 31, 125, 242, 217, 23, 95, 125, 243,
-                        221, 15, 63, 27, 253, 46, 16, 248, 11, 162, 195, 225, 90])
-                   .try_into());
+    assert_eq!(
+        Ok(List::from(
+            (1..257)
+                .map(|i| Term::from(FixInteger::from(i)))
+                .collect::<Vec<_>>()
+        )),
+        decode(&[
+            131, 80, 0, 0, 2, 9, 120, 218, 21, 210, 3, 187, 16, 6, 0, 0, 192, 151, 237, 150, 173,
+            101, 219, 54, 182, 236, 186, 220, 235, 101, 219, 182, 237, 150, 93, 219, 178, 109, 219,
+            182, 237, 175, 251, 13, 23, 20, 16, 16, 44, 64, 48, 193, 133, 16, 82, 40, 161, 133, 17,
+            86, 56, 225, 69, 16, 81, 36, 145, 69, 17, 85, 52, 209, 197, 16, 211, 31, 98, 137, 45,
+            142, 184, 226, 137, 47, 129, 132, 18, 73, 44, 137, 164, 146, 73, 46, 133, 148, 82, 249,
+            83, 106, 105, 164, 149, 78, 122, 25, 100, 148, 73, 102, 89, 100, 149, 77, 118, 57, 228,
+            148, 75, 110, 121, 228, 149, 79, 126, 5, 20, 84, 72, 97, 69, 20, 85, 76, 113, 37, 148,
+            84, 74, 105, 101, 148, 85, 78, 121, 21, 84, 84, 201, 95, 254, 86, 89, 21, 85, 85, 83,
+            93, 13, 53, 213, 82, 91, 29, 117, 213, 83, 95, 3, 13, 209, 72, 99, 77, 52, 213, 76,
+            115, 45, 180, 20, 168, 149, 32, 173, 181, 209, 86, 59, 237, 117, 208, 81, 39, 157, 117,
+            209, 85, 55, 221, 245, 208, 83, 47, 189, 245, 209, 87, 63, 253, 13, 48, 208, 32, 131,
+            13, 49, 212, 48, 195, 141, 48, 210, 40, 163, 141, 49, 214, 56, 227, 77, 48, 209, 36,
+            147, 77, 49, 213, 52, 211, 205, 48, 211, 44, 179, 205, 49, 215, 60, 243, 45, 176, 208,
+            34, 255, 88, 108, 137, 165, 150, 89, 110, 133, 149, 86, 89, 109, 141, 181, 214, 89,
+            111, 131, 141, 254, 245, 159, 255, 109, 178, 217, 22, 91, 109, 179, 221, 14, 59, 237,
+            178, 219, 30, 123, 237, 179, 223, 1, 7, 29, 114, 216, 17, 71, 29, 115, 220, 9, 39, 157,
+            114, 218, 25, 103, 157, 115, 222, 5, 23, 93, 114, 217, 21, 87, 93, 115, 221, 13, 55,
+            221, 114, 219, 29, 119, 221, 115, 223, 3, 15, 61, 242, 216, 19, 79, 61, 243, 220, 11,
+            47, 189, 242, 218, 27, 111, 189, 243, 222, 7, 31, 125, 242, 217, 23, 95, 125, 243, 221,
+            15, 63, 27, 253, 46, 16, 248, 11, 162, 195, 225, 90
+        ])
+        .try_into()
+    );
 }
 
 fn encode(term: Term) -> Vec<u8> {


### PR DESCRIPTION
Erlang ETF explicitly forbids the use of non-finite floats in `NEW_FLOAT_EXT` and `FLOAT_EXT`, so this should be caught both on unpacking as well as on writing. This means, however, that `Float` can
not always be converted from `f32` and `f64`, so the respective `From` implementations have to be replaced by `TryFrom`.

This PR is based on #1, so that one should be merged first.

The change breaks backwards compatibility.