### PR TITLE
Decreased Enum Size by Boxing, Changed Map to use HashMap internally, Added ByteList for STRING_EXT

### DIFF
--- a/src/codec.rs
+++ b/src/codec.rs
@@ -202,13 +202,13 @@ impl<R: io::Read> Decoder<R> {
     }
     fn decode_map_ext(&mut self) -> DecodeResult {
         let count = self.reader.read_u32::<BigEndian>()? as usize;
-        let mut entries = Vec::with_capacity(count);
+        let mut map = HashMap::<Term,Term>::new();
         for _ in 0..count {
             let k = self.decode_term()?;
             let v = self.decode_term()?;
-            entries.push((k, v));
+            map.insert(k, v);
         }
-        Ok(Term::from(Map::from(entries)))
+        Ok(Term::from(Map::from(map)))
     }
     fn decode_binary_ext(&mut self) -> DecodeResult {
         let size = self.reader.read_u32::<BigEndian>()? as usize;
@@ -525,8 +525,8 @@ impl<W: io::Write> Encoder<W> {
     }
     fn encode_map(&mut self, x: &Map) -> EncodeResult {
         self.writer.write_u8(MAP_EXT)?;
-        self.writer.write_u32::<BigEndian>(x.entries.len() as u32)?;
-        for &(ref k, ref v) in &x.entries {
+        self.writer.write_u32::<BigEndian>(x.map.len() as u32)?;
+        for (k, v) in x.map.iter() {
             self.encode_term(k)?;
             self.encode_term(v)?;
         }

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -38,6 +38,7 @@ impl_term_try_as_ref!(List);
 impl_term_try_as_ref!(ImproperList);
 impl_term_try_as_ref!(Tuple);
 impl_term_try_as_ref!(Map);
+impl_term_try_as_ref!(ByteList);
 
 macro_rules! impl_term_try_into {
     ($to:ident) => {
@@ -88,6 +89,7 @@ impl_term_try_into!(List);
 impl_term_try_into!(ImproperList);
 impl_term_try_into!(Tuple);
 impl_term_try_into!(Map);
+impl_term_try_into!(ByteList);
 
 pub trait AsOption {
     fn as_option(&self) -> Option<&Self>;

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -56,15 +56,32 @@ macro_rules! impl_term_try_into {
         }
     };
 }
+macro_rules! impl_term_try_into_boxed {
+    ($to:ident) => {
+        impl TryInto<$to> for Term {
+            type Error = Self;
+
+            fn try_into(self) -> Result<$to, Self>
+            where
+                Self: Sized,
+            {
+                match self {
+                    Term::$to(x) => Ok(*x),
+                    _ => Err(self),
+                }
+            }
+        }
+    };
+}
 impl_term_try_into!(Atom);
 impl_term_try_into!(FixInteger);
 impl_term_try_into!(BigInteger);
 impl_term_try_into!(Float);
 impl_term_try_into!(Pid);
 impl_term_try_into!(Port);
-impl_term_try_into!(Reference);
-impl_term_try_into!(ExternalFun);
-impl_term_try_into!(InternalFun);
+impl_term_try_into_boxed!(Reference);
+impl_term_try_into_boxed!(ExternalFun);
+impl_term_try_into_boxed!(InternalFun);
 impl_term_try_into!(Binary);
 impl_term_try_into!(BitBinary);
 impl_term_try_into!(List);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,9 @@
 //! - [Erlang External Term Format](http://erlang.org/doc/apps/erts/erl_ext_dist.html)
 //!
 use num::bigint::BigInt;
+use std::collections::HashMap;
 use std::fmt;
+use std::hash::Hash;
 use std::io;
 
 mod codec;
@@ -719,14 +721,14 @@ impl From<Vec<Term>> for Tuple {
 }
 
 /// Map.
-#[derive(Debug, PartialEq, Eq, Hash, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Map {
-    pub entries: Vec<(Term, Term)>,
+    pub map: HashMap<Term, Term>,
 }
 impl fmt::Display for Map {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {  
         write!(f, "#{{")?;
-        for (i, &(ref k, ref v)) in self.entries.iter().enumerate() {
+        for (i, (k, v)) in self.map.iter().enumerate() {
             if i != 0 {
                 write!(f, ",")?;
             }
@@ -734,6 +736,24 @@ impl fmt::Display for Map {
         }
         write!(f, "}}")?;
         Ok(())
+    }
+}
+impl Hash for Map {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        for (k, v) in self.map.iter() {
+            k.hash(state);
+            v.hash(state);
+        }
+    }
+}
+impl<const N: usize> From<[(Term,Term); N]> for Map{
+    fn from(from: [(Term,Term); N]) -> Self {
+        Map{ map : HashMap::from(from)  }
+    }
+}
+impl From<HashMap<Term,Term>> for Map{
+    fn from(from_map: HashMap<Term,Term>) -> Self {
+        Map{ map :from_map  }
     }
 }
 impl From<Vec<(Term, Term)>> for Map {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,6 +57,7 @@ pub enum Term {
     InternalFun(Box<InternalFun>),
     Binary(Binary),
     BitBinary(BitBinary),
+    ByteList(ByteList),
     List(List),
     ImproperList(ImproperList),
     Tuple(Tuple),
@@ -94,6 +95,7 @@ impl fmt::Display for Term {
             Term::InternalFun(ref x) => x.fmt(f),
             Term::Binary(ref x) => x.fmt(f),
             Term::BitBinary(ref x) => x.fmt(f),
+            Term::ByteList(ref x) => x.fmt(f),
             Term::List(ref x) => x.fmt(f),
             Term::ImproperList(ref x) => x.fmt(f),
             Term::Tuple(ref x) => x.fmt(f),
@@ -154,6 +156,16 @@ impl From<Binary> for Term {
 impl From<BitBinary> for Term {
     fn from(x: BitBinary) -> Self {
         Term::BitBinary(x)
+    }
+}
+impl From<ByteList> for Term {
+    fn from(x: ByteList) -> Self {
+        Term::ByteList(x)
+    }
+}
+impl From<String> for Term {
+    fn from(x: String) -> Self {
+        Term::ByteList(ByteList { bytes: x.into_bytes() })
     }
 }
 impl From<List> for Term {
@@ -623,6 +635,55 @@ impl From<(Vec<u8>, u8)> for BitBinary {
     }
 }
 
+
+/// Erlang has a transport optimization for lists only containing u8 elements. \
+/// Since Strings in erlang are just lists with u8's they call this "STRING_EXT". 
+/// 
+/// This type does not exist in erlang and is to be seen as a subtype of List.
+/// 
+/// See: https://erlang.org/doc/apps/erts/erl_ext_dist.html#STRING_EXT
+/// 
+#[derive(Debug, PartialEq, Eq, Hash, Clone)]
+pub struct ByteList {
+    pub bytes: Vec<u8>,
+}
+impl fmt::Display for ByteList {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "[")?;
+        for (i, b) in self.bytes.iter().enumerate() {
+            if i != 0 {
+                write!(f, ",")?;
+            }
+            write!(f, "{}", b)?;
+        }
+        write!(f, "]")?;
+        Ok(())
+    }
+}
+impl From<String> for ByteList {
+    fn from(string: String) -> Self {
+        ByteList { bytes : string.into_bytes()}
+    }
+}
+impl From<&str> for ByteList {
+    fn from(string: &str) -> Self {
+        ByteList { bytes :string.into() } 
+    }
+}
+impl From<Vec<u8>> for ByteList {
+    fn from(bytes: Vec<u8>) -> Self {
+        ByteList { bytes }
+    }
+}
+impl<const N: usize> From<&[u8;N]> for ByteList {
+    fn from(bytes: &[u8;N]) -> Self {
+        ByteList {
+            bytes: Vec::from(bytes.as_slice()),
+        }
+    }
+}
+
+
 /// List.
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub struct List {
@@ -656,6 +717,12 @@ impl fmt::Display for List {
 }
 impl From<Vec<Term>> for List {
     fn from(elements: Vec<Term>) -> Self {
+        List { elements }
+    }
+}
+impl From<ByteList> for List {
+    fn from(byte_list: ByteList) -> Self {
+        let elements = byte_list.bytes.into_iter().map(|value|Term::FixInteger(FixInteger { value: value as i32 })).collect();
         List { elements }
     }
 }
@@ -756,9 +823,13 @@ impl From<HashMap<Term,Term>> for Map{
         Map{ map :from_map  }
     }
 }
-impl From<Vec<(Term, Term)>> for Map {
-    fn from(entries: Vec<(Term, Term)>) -> Self {
-        Map { entries }
+impl From<HashMap<String,Term>> for Map{
+    fn from(from_map: HashMap<String,Term>) -> Self {
+        let mut result_map = HashMap::<Term,Term>::new();
+        for (k,v) in from_map {
+            result_map.insert(Term::from(k),v);
+        }
+        Map{ map : result_map  }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,9 +50,9 @@ pub enum Term {
     Float(Float),
     Pid(Pid),
     Port(Port),
-    Reference(Reference),
-    ExternalFun(ExternalFun),
-    InternalFun(InternalFun),
+    Reference(Box<Reference>),
+    ExternalFun(Box<ExternalFun>),
+    InternalFun(Box<InternalFun>),
     Binary(Binary),
     BitBinary(BitBinary),
     List(List),
@@ -131,17 +131,17 @@ impl From<Port> for Term {
 }
 impl From<Reference> for Term {
     fn from(x: Reference) -> Self {
-        Term::Reference(x)
+        Term::Reference(Box::new(x))
     }
 }
 impl From<ExternalFun> for Term {
     fn from(x: ExternalFun) -> Self {
-        Term::ExternalFun(x)
+        Term::ExternalFun(Box::new(x))
     }
 }
 impl From<InternalFun> for Term {
     fn from(x: InternalFun) -> Self {
-        Term::InternalFun(x)
+        Term::InternalFun(Box::new(x))
     }
 }
 impl From<Binary> for Term {


### PR DESCRIPTION
Hello Takeru,

I'm using this library in a prototype of mine. 
There were some QOL things I wanted to change for myself, which is why I'm offering this PR.

All of these are Breaking Changes!

The changes include:
1. Boxing the Large Terms like Reference, ExternalFun, InternalFun to decrease the size of the enum from ~152bit to ~64bit
2. Changing the Map to actually use a HashMap, simplifying it's use.
3. Adding ByteList to handle STRING_EXT
     -> This can cause issues when a system happens to send a list of numbers which could but are not neccesarily under u8 as this would cause matches which expect a ByteList to fail.

I'll leave it up to you if you are interested in these changes. 

Best Regards!  