### PR TITLE
Replace `num` with `num-bigint` and `num-traits`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ license = "MIT"
 edition = "2021"
 
 [dependencies]
-num = "0.4"
 byteorder = "1"
 libflate = "2"
+num-bigint = "0.4"
+num-traits = "0.2.19"

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -4,7 +4,7 @@ use byteorder::BigEndian;
 use byteorder::ReadBytesExt;
 use byteorder::WriteBytesExt;
 use libflate::zlib;
-use num::bigint::BigInt;
+use num_bigint::BigInt;
 use std::convert::From;
 use std::io;
 use std::io::Write;
@@ -767,7 +767,7 @@ impl<W: io::Write> Encoder<W> {
 }
 
 mod aux {
-    use num::bigint::Sign;
+    use num_bigint::Sign;
     use std::io;
     use std::ops::Range;
     use std::str;

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -104,7 +104,7 @@ impl AsOption for bool {
     }
 }
 
-impl num::traits::ToPrimitive for FixInteger {
+impl num_traits::ToPrimitive for FixInteger {
     fn to_i64(&self) -> Option<i64> {
         Some(i64::from(self.value))
     }
@@ -115,7 +115,7 @@ impl num::traits::ToPrimitive for FixInteger {
         Some(f64::from(self.value))
     }
 }
-impl num::traits::ToPrimitive for BigInteger {
+impl num_traits::ToPrimitive for BigInteger {
     fn to_i64(&self) -> Option<i64> {
         self.value.to_i64()
     }
@@ -126,7 +126,7 @@ impl num::traits::ToPrimitive for BigInteger {
         self.value.to_f64()
     }
 }
-impl num::traits::ToPrimitive for Float {
+impl num_traits::ToPrimitive for Float {
     fn to_i64(&self) -> Option<i64> {
         None
     }
@@ -137,7 +137,7 @@ impl num::traits::ToPrimitive for Float {
         Some(self.value)
     }
 }
-impl num::traits::ToPrimitive for Term {
+impl num_traits::ToPrimitive for Term {
     fn to_i64(&self) -> Option<i64> {
         match *self {
             Term::FixInteger(ref x) => x.to_i64(),
@@ -162,18 +162,18 @@ impl num::traits::ToPrimitive for Term {
     }
 }
 
-impl num::bigint::ToBigInt for FixInteger {
-    fn to_bigint(&self) -> Option<num::bigint::BigInt> {
+impl num_bigint::ToBigInt for FixInteger {
+    fn to_bigint(&self) -> Option<num_bigint::BigInt> {
         Some(BigInteger::from(self).value)
     }
 }
-impl num::bigint::ToBigInt for BigInteger {
-    fn to_bigint(&self) -> Option<num::bigint::BigInt> {
+impl num_bigint::ToBigInt for BigInteger {
+    fn to_bigint(&self) -> Option<num_bigint::BigInt> {
         Some(self.value.clone())
     }
 }
-impl num::bigint::ToBigInt for Term {
-    fn to_bigint(&self) -> Option<num::bigint::BigInt> {
+impl num_bigint::ToBigInt for Term {
+    fn to_bigint(&self) -> Option<num_bigint::BigInt> {
         match *self {
             Term::FixInteger(ref x) => x.to_bigint(),
             Term::BigInteger(ref x) => x.to_bigint(),
@@ -182,18 +182,18 @@ impl num::bigint::ToBigInt for Term {
     }
 }
 
-impl num::bigint::ToBigUint for FixInteger {
-    fn to_biguint(&self) -> Option<num::bigint::BigUint> {
+impl num_bigint::ToBigUint for FixInteger {
+    fn to_biguint(&self) -> Option<num_bigint::BigUint> {
         BigInteger::from(self).value.to_biguint()
     }
 }
-impl num::bigint::ToBigUint for BigInteger {
-    fn to_biguint(&self) -> Option<num::bigint::BigUint> {
+impl num_bigint::ToBigUint for BigInteger {
+    fn to_biguint(&self) -> Option<num_bigint::BigUint> {
         self.value.to_biguint()
     }
 }
-impl num::bigint::ToBigUint for Term {
-    fn to_biguint(&self) -> Option<num::bigint::BigUint> {
+impl num_bigint::ToBigUint for Term {
+    fn to_biguint(&self) -> Option<num_bigint::BigUint> {
         match *self {
             Term::FixInteger(ref x) => x.to_biguint(),
             Term::BigInteger(ref x) => x.to_biguint(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@
 //!
 //! - [Erlang External Term Format](http://erlang.org/doc/apps/erts/erl_ext_dist.html)
 //!
-use num::bigint::BigInt;
+use num_bigint::BigInt;
 use std::collections::HashMap;
 use std::fmt;
 use std::hash::Hash;
@@ -557,7 +557,7 @@ impl fmt::Display for InternalFun {
                 uniq,
                 ..
             } => {
-                use num::bigint::Sign;
+                use num_bigint::Sign;
                 let uniq = BigInt::from_bytes_be(Sign::Plus, &uniq);
                 write!(f, "#Fun<{}.{}.{}>", module, index, uniq)
             }

--- a/src/pattern.rs
+++ b/src/pattern.rs
@@ -3,9 +3,9 @@
 use super::*;
 use crate::convert::AsOption;
 use crate::convert::TryAsRef;
-use num::bigint::ToBigInt;
-use num::bigint::ToBigUint;
-use num::traits::ToPrimitive;
+use num_bigint::ToBigInt;
+use num_bigint::ToBigUint;
+use num_traits::ToPrimitive;
 use std::fmt::Debug;
 
 pub type Result<'a, T> = std::result::Result<T, Unmatch<'a>>;
@@ -838,7 +838,7 @@ impl<'a> Pattern<'a> for I64 {
 #[derive(Debug, Clone)]
 pub struct Int;
 impl<'a> Pattern<'a> for Int {
-    type Output = num::BigInt;
+    type Output = num_bigint::BigInt;
     fn try_match(&self, input: &'a Term) -> Result<'a, Self::Output> {
         input.to_bigint().ok_or_else(|| self.unmatched(input))
     }
@@ -847,7 +847,7 @@ impl<'a> Pattern<'a> for Int {
 #[derive(Debug, Clone)]
 pub struct Uint;
 impl<'a> Pattern<'a> for Uint {
-    type Output = num::BigUint;
+    type Output = num_bigint::BigUint;
     fn try_match(&self, input: &'a Term) -> Result<'a, Self::Output> {
         input.to_biguint().ok_or_else(|| self.unmatched(input))
     }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,6 +1,3 @@
-extern crate eetf;
-extern crate num;
-
 use eetf::*;
 use std::io::Cursor;
 


### PR DESCRIPTION
Copilot Summary
----------------

This pull request includes changes to update dependencies and refactor code to use the new `num-bigint` and `num-traits` crates. The most important changes include updating the `Cargo.toml` file, modifying import statements, and refactoring implementations to use the new crates.

Dependency updates:

* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L15-R18): Added `num-bigint` and `num-traits` dependencies and removed the old `num` dependency.

Import statement updates:

* [`src/codec.rs`](diffhunk://#diff-ca14eabd5ab83f72548cd7e44eaea3f56a5d2808e3275c6b2a97622ebe5d1dd0L7-R7): Updated import statements to use `num_bigint` instead of `num::bigint`. [[1]](diffhunk://#diff-ca14eabd5ab83f72548cd7e44eaea3f56a5d2808e3275c6b2a97622ebe5d1dd0L7-R7) [[2]](diffhunk://#diff-ca14eabd5ab83f72548cd7e44eaea3f56a5d2808e3275c6b2a97622ebe5d1dd0L770-R770)
* [`src/lib.rs`](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L31-R31): Updated import statements to use `num_bigint` instead of `num::bigint`. [[1]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L31-R31) [[2]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L560-R560)
* [`src/pattern.rs`](diffhunk://#diff-df0ea49b7ccb31d507c9b270c520d68bb3e2c36e6c3ac980e46c39e2b782fffbL6-R8): Updated import statements to use `num_bigint` and `num_traits` instead of `num::bigint` and `num::traits`. [[1]](diffhunk://#diff-df0ea49b7ccb31d507c9b270c520d68bb3e2c36e6c3ac980e46c39e2b782fffbL6-R8) [[2]](diffhunk://#diff-df0ea49b7ccb31d507c9b270c520d68bb3e2c36e6c3ac980e46c39e2b782fffbL841-R841) [[3]](diffhunk://#diff-df0ea49b7ccb31d507c9b270c520d68bb3e2c36e6c3ac980e46c39e2b782fffbL850-R850)

Code refactoring:

* [`src/convert.rs`](diffhunk://#diff-d42cae02d6ab6561d7a3d9a4d5538b03cdb33e075dfe41a89e70fd8206d9eaabL107-R107): Refactored implementations to use `num_traits::ToPrimitive` and `num_bigint::ToBigInt` and `ToBigUint` instead of the old `num` crate equivalents. [[1]](diffhunk://#diff-d42cae02d6ab6561d7a3d9a4d5538b03cdb33e075dfe41a89e70fd8206d9eaabL107-R107) [[2]](diffhunk://#diff-d42cae02d6ab6561d7a3d9a4d5538b03cdb33e075dfe41a89e70fd8206d9eaabL118-R118) [[3]](diffhunk://#diff-d42cae02d6ab6561d7a3d9a4d5538b03cdb33e075dfe41a89e70fd8206d9eaabL129-R129) [[4]](diffhunk://#diff-d42cae02d6ab6561d7a3d9a4d5538b03cdb33e075dfe41a89e70fd8206d9eaabL140-R140) [[5]](diffhunk://#diff-d42cae02d6ab6561d7a3d9a4d5538b03cdb33e075dfe41a89e70fd8206d9eaabL165-R176) [[6]](diffhunk://#diff-d42cae02d6ab6561d7a3d9a4d5538b03cdb33e075dfe41a89e70fd8206d9eaabL185-R196)

Test file cleanup:

* [`tests/lib.rs`](diffhunk://#diff-6d1e3ec7ab6aaf7a94f9c1e9a423db6de6e4a1bec380dae17cc6e635f1db8854L1-L3): Removed unnecessary `extern crate` declarations for `eetf` and `num`.